### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
-## [0.3.0] — Unreleased
+## [0.3.1] — 2026-04-28
 
-First standalone release. Extracts the D-Bus notification daemon from
-[`mac-doc-hyprland`](https://github.com/jasonherald/mac-doc-hyprland) as its
-own repo + crates.io crate.
-
-### Changed
-
-- Dependency: `nwg-common` now consumed from crates.io at `"0.3"` rather than
-  as a workspace path dependency.
-- D-Bus service file now ships as a committed template
-  (`data/org.freedesktop.Notifications.service.in`) that `make install-dbus`
-  substitutes `@BIN_PATH@` in, rather than being generated via `echo` at
-  install time. Easier to inspect and version-control.
+Closes the [nwg-shell-config integration epic](https://github.com/jasonherald/nwg-notifications/issues/8) on the daemon side: adds the flags and IPC surface that `nwg-shell-config` needs to drive `nwg-notifications` directly (replacing swaync), plus a small D-Bus protocol fix surfaced during review.
 
 ### Added
 
-- crates.io metadata (`description`, `readme`, `keywords`, `categories`,
-  `repository`) wired up.
 - `--popup-position` accepts `top-center` and `bottom-center` in addition to
   the existing four corners. Centered placements anchor only the top or
   bottom edge; gtk4-layer-shell centers the surface horizontally on the
@@ -55,4 +42,24 @@ own repo + crates.io crate.
   `org.freedesktop.DBus.Error.UnknownMethod` for unknown methods instead of
   silently logging, so introspection-driven clients see the error
   immediately instead of waiting out their reply timeout. Mirrors the fix
-  for the nwg-count handler in #14. (#15)
+  applied to the new `org.nwg.Notifications` handler. (#15)
+
+## [0.3.0] — 2026-04-21
+
+First standalone release. Extracts the D-Bus notification daemon from
+[`mac-doc-hyprland`](https://github.com/jasonherald/mac-doc-hyprland) as its
+own repo + crates.io crate.
+
+### Changed
+
+- Dependency: `nwg-common` now consumed from crates.io at `"0.3"` rather than
+  as a workspace path dependency.
+- D-Bus service file now ships as a committed template
+  (`data/org.freedesktop.Notifications.service.in`) that `make install-dbus`
+  substitutes `@BIN_PATH@` in, rather than being generated via `echo` at
+  install time. Easier to inspect and version-control.
+
+### Added
+
+- crates.io metadata (`description`, `readme`, `keywords`, `categories`,
+  `repository`) wired up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-notifications"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-notifications"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # nwg-notifications
 
+[![crates.io](https://img.shields.io/crates/v/nwg-notifications.svg)](https://crates.io/crates/nwg-notifications)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A D-Bus notification daemon and notification center for [Hyprland](https://hyprland.org/) and [Sway](https://swaywm.org/), written in Rust.
 
 Claims `org.freedesktop.Notifications`, shows popup toasts, and ships a slide-out history panel with Do-Not-Disturb controls and optional waybar integration. Built alongside [`nwg-dock`](https://github.com/jasonherald/nwg-dock) and [`nwg-drawer`](https://github.com/jasonherald/nwg-drawer) to replace [mako](https://github.com/emersion/mako) in the mac-doc-hyprland stack, but runs standalone.
@@ -41,9 +44,17 @@ sudo apt install libgtk-4-dev libgtk4-layer-shell-dev
 sudo dnf install gtk4-devel gtk4-layer-shell-devel
 ```
 
-### `make install` — three invocations for the binary + a user-scope `install-dbus`
+### From crates.io (recommended for end users)
 
-The binary install has three invocations. The **D-Bus service file always lands in user-scope** (`~/.local/share/dbus-1/services/`) regardless of `PREFIX` — D-Bus user services are per-user by convention, and installing the service file system-wide would break auto-activation for other users on the same machine.
+```bash
+cargo install nwg-notifications
+```
+
+Lands the binary at `~/.cargo/bin/nwg-notifications`. `cargo install` doesn't ship the D-Bus service file — you'll need to write that yourself (see [D-Bus service](#d-bus-service) below; it's a ~5-line file pointing at the installed binary). Once the service file is in place, the daemon auto-activates the first time any app calls `org.freedesktop.Notifications`.
+
+### `make install` — for source builds, distro packagers, and the `install-dbus` helper
+
+The Makefile install path drops both the binary and the D-Bus service file (the latter always to user-scope, regardless of `PREFIX` — D-Bus user services are per-user by convention).
 
 **Default — system-wide binary + user-scope service:**
 
@@ -69,14 +80,6 @@ make install-dbus
 sudo make install PREFIX=/usr
 make install-dbus
 ```
-
-### From crates.io
-
-```bash
-cargo install nwg-notifications
-```
-
-`cargo install` only installs the binary. You'll need to write the D-Bus service file yourself (see [D-Bus service](#d-bus-service) below) — it's a ~5-line file pointing at `~/.cargo/bin/nwg-notifications`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Release prep for crates.io publish:

- **Cargo.toml**: bumps version 0.3.0 → 0.3.1.
- **CHANGELOG**: splits the existing `[0.3.0] — Unreleased` entry. 0.3.0 retains its actual original content (standalone-release packaging changes, crates.io metadata, dated 2026-04-21 to match its real publish date). Everything added since (popup-position centers #10, count IPC #9, popup-width #11, panel-width #12, freedesktop UnknownMethod fix #15) moves into a new `[0.3.1] — 2026-04-28` section.
- **README**: promotes \`cargo install nwg-notifications\` as the recommended end-user install path (now that the crate is actually on crates.io), with the Makefile invocations kept below for source builds. Adds crates.io version + MIT license shields at the top of the README.

All 0.3.1 changes are purely additive — new flags, new D-Bus interface, new status-JSON field, new CLI subcommand. No removed or renamed public surface, so this is a patch-level bump per SemVer 0.x.

## Test plan

- [x] \`make lint\` — fmt + clippy + test + deny + audit, all green locally.
- [x] All 57 unit tests pass against version 0.3.1.

## After merge

- Pull main, tag \`v0.3.1\`, push tag.
- \`cargo publish --dry-run\` to validate.
- \`cargo publish\` for real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed protocol issue with UnknownMethod error-return behavior in the notification handler.

* **Documentation**
  * Updated installation guide to recommend crates.io as the primary installation method with explicit details on D-Bus service file setup and binary location.
  * Published release v0.3.1 with completion of the shell-config integration epic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->