### PR TITLE
Release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
-## [Unreleased]
+## [0.3.2] — 2026-04-29
+
+Adds a live config update mechanism so consumers like `nwg-shell-config` can change runtime settings without restarting the daemon.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-notifications"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-notifications"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release prep for crates.io publish:

- **Cargo.toml**: bumps version 0.3.1 → 0.3.2.
- **CHANGELOG**: promotes the existing \`[Unreleased]\` block to \`[0.3.2] — 2026-04-29\`.

0.3.2 ships the live config update mechanism (#20):

- Six D-Bus setters on \`org.nwg.Notifications\` (\`SetPopupPosition\`, \`SetPopupWidth\`, \`SetPanelWidth\`, \`SetPopupTimeout\`, \`SetMaxPopups\`, \`SetMaxHistory\`) — validating, returning \`InvalidArgs\` on bad input.
- \`nwg-notifications --update <flags>\` CLI subcommand using \`value_source()\` to push only user-set flags.

Purely additive — no removed or renamed public surface, so this is a patch-level bump per SemVer 0.x.

## Test plan

- [x] \`make lint\` — fmt + clippy + test + deny + audit, all green locally.
- [x] All 63 unit tests pass against version 0.3.2.

## After merge

- Pull main, tag \`v0.3.2\`, push tag.
- \`cargo publish --dry-run\` to validate.
- \`cargo publish\` for real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live configuration update mechanism enabling runtime settings changes without daemon restart.

* **Chores**
  * Released version 0.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->