### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
-## [0.3.3] — Unreleased
+## [0.3.3] — 2026-04-29
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-notifications"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-notifications"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release prep for crates.io publish:

- **Cargo.toml**: bumps version 0.3.2 → 0.3.3.
- **CHANGELOG**: promotes \`[0.3.3] — Unreleased\` → \`[0.3.3] — 2026-04-29\`.

0.3.3 ships the panel-open-dismisses-popups fix (#3): visible popup toasts now disappear when the panel slides in instead of overlapping its edge. Pure UI dedup — popups aren't marked read or removed from history.

Patch-level bump per SemVer 0.x — no API changes.

## Test plan

- [x] \`make lint\` — fmt + clippy + test + deny + audit, all green locally.
- [x] All 63 unit tests pass against version 0.3.3.

## After merge

- Pull main, tag \`v0.3.3\`, push tag.
- \`cargo publish --dry-run\` to validate.
- \`cargo publish\` for real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.3.3
  * Changelog finalized with release date

<!-- end of auto-generated comment: release notes by coderabbit.ai -->