### PR TITLE
Actionable --update error + README install rebalance (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
+## [0.3.4] — Unreleased
+
+### Fixed
+
+- `--update` now prints an actionable error when it calls a D-Bus
+  method the running daemon doesn't recognise — typically because the
+  daemon is from a release older than the CLI. Previously the raw
+  `GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod` text bubbled
+  to the user, which didn't hint at the restart-after-upgrade fix.
+  Other error classes (no daemon, timeout, payload type) keep their
+  existing format. (#25)
+
 ## [0.3.3] — 2026-04-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Lands the binary at `~/.cargo/bin/nwg-notifications`. `cargo install` doesn't sh
 
 **After upgrading**, restart any long-running daemon process so it picks up new D-Bus surface introduced by the upgrade. The CLI on `PATH` will be the new binary immediately, but the daemon process started by your session manager (or auto-activated by D-Bus before the upgrade) keeps running the old code until it exits. Quickest restart:
 
-````bash
+```bash
 kill $(pidof nwg-notifications)
 # Your session manager (or D-Bus auto-activation on the next notify-send)
 # spawns the new binary. Or run `nwg-notifications --persist &` directly.
-````
+```
 
 Without this, `--update` and `gdbus call` against newly-shipped methods fail with `org.freedesktop.DBus.Error.UnknownMethod`.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo make install PREFIX=/usr
 make install-dbus
 ```
 
-**`make upgrade` — one-step build + install + daemon restart:**
+### `make upgrade` — one-step build + install + daemon restart
 
 For source-build users on an already-installed setup, `make upgrade` does the whole replace-and-respawn cycle in one command. It builds release, validates that the running daemon's binary path matches where this `make upgrade` would install (refusing to proceed on a prefix mismatch so you don't end up with a dead daemon), captures the running daemon's args via `--dump-args`, sends `SIGTERM`, installs the new binary, and respawns with the same args.
 
@@ -108,7 +108,7 @@ kill $(pidof nwg-notifications)
 # spawns the new binary. Or run `nwg-notifications --persist &` directly.
 ```
 
-If you happen to have a source clone of the repo as well, [`make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin`](#make-install--recommended-one-stop-binary--d-bus-service-file) automates the whole replace-and-respawn cycle (and preserves the running daemon's args).
+If you happen to have a source clone of the repo as well, [`make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin`](#make-upgrade--one-step-build--install--daemon-restart) automates the whole replace-and-respawn cycle (and preserves the running daemon's args).
 
 Without this, `--update` and `gdbus call` against newly-shipped methods fail with `org.freedesktop.DBus.Error.UnknownMethod`.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ cargo install nwg-notifications
 
 Lands the binary at `~/.cargo/bin/nwg-notifications`. `cargo install` doesn't ship the D-Bus service file — you'll need to write that yourself (see [D-Bus service](#d-bus-service) below; it's a ~5-line file pointing at the installed binary). Once the service file is in place, the daemon auto-activates the first time any app calls `org.freedesktop.Notifications`.
 
+**After upgrading**, restart any long-running daemon process so it picks up new D-Bus surface introduced by the upgrade. The CLI on `PATH` will be the new binary immediately, but the daemon process started by your session manager (or auto-activated by D-Bus before the upgrade) keeps running the old code until it exits. Quickest restart:
+
+````bash
+kill $(pidof nwg-notifications)
+# Your session manager (or D-Bus auto-activation on the next notify-send)
+# spawns the new binary. Or run `nwg-notifications --persist &` directly.
+````
+
+Without this, `--update` and `gdbus call` against newly-shipped methods fail with `org.freedesktop.DBus.Error.UnknownMethod`.
+
 ### `make install` — for source builds, distro packagers, and the `install-dbus` helper
 
 The Makefile install path drops both the binary and the D-Bus service file (the latter always to user-scope, regardless of `PREFIX` — D-Bus user services are per-user by convention).

--- a/README.md
+++ b/README.md
@@ -78,13 +78,17 @@ make install-dbus
 
 For source-build users on an already-installed setup, `make upgrade` does the whole replace-and-respawn cycle in one command. It builds release, validates that the running daemon's binary path matches where this `make upgrade` would install (refusing to proceed on a prefix mismatch so you don't end up with a dead daemon), captures the running daemon's args via `--dump-args`, sends `SIGTERM`, installs the new binary, and respawns with the same args.
 
+**The recommended dev/test recipe — drops the binary at `~/.cargo/bin/nwg-notifications` (the same place `cargo install` would put it), no sudo:**
+
 ```bash
 make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
 ```
 
-(Or `sudo make upgrade` for system-wide installs — same prefix matching applies.)
+This is what we use to dogfood every PR — install once, then `make upgrade PREFIX=... BINDIR=...` for every iteration. It also doubles as the upgrade path for users who originally installed via `cargo install nwg-notifications`: keep a source clone, run `make upgrade` against `~/.cargo/bin`, and you get the rebuild + install + restart loop without the manual kill-and-respawn dance.
 
-This is the recommended path for the source-build workflow once the daemon is already running. Cargo-install users don't have it; see the "After upgrading" note in the [From crates.io](#from-cratesio--rust-toolchain-alternative) subsection below for the manual equivalent.
+For system-wide installs use `sudo make upgrade` (or `sudo make upgrade PREFIX=/usr` for distro-parity) — same prefix-matching guard applies, refusing to proceed if the running daemon lives somewhere else.
+
+Cargo-install users without a source clone should use the manual equivalent — see the "After upgrading" note in the [From crates.io](#from-cratesio--rust-toolchain-alternative) subsection below.
 
 ### From crates.io — Rust-toolchain alternative
 
@@ -103,6 +107,8 @@ kill $(pidof nwg-notifications)
 # Your session manager (or D-Bus auto-activation on the next notify-send)
 # spawns the new binary. Or run `nwg-notifications --persist &` directly.
 ```
+
+If you happen to have a source clone of the repo as well, [`make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin`](#make-install--recommended-one-stop-binary--d-bus-service-file) automates the whole replace-and-respawn cycle (and preserves the running daemon's args).
 
 Without this, `--update` and `gdbus call` against newly-shipped methods fail with `org.freedesktop.DBus.Error.UnknownMethod`.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ sudo make install PREFIX=/usr
 make install-dbus
 ```
 
+**`make upgrade` — one-step build + install + daemon restart:**
+
+For source-build users on an already-installed setup, `make upgrade` does the whole replace-and-respawn cycle in one command. It builds release, validates that the running daemon's binary path matches where this `make upgrade` would install (refusing to proceed on a prefix mismatch so you don't end up with a dead daemon), captures the running daemon's args via `--dump-args`, sends `SIGTERM`, installs the new binary, and respawns with the same args.
+
+```bash
+make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+(Or `sudo make upgrade` for system-wide installs — same prefix matching applies.)
+
+This is the recommended path for the source-build workflow once the daemon is already running. Cargo-install users don't have it; see the "After upgrading" note in the [From crates.io](#from-cratesio-recommended-for-end-users) subsection above for the manual equivalent.
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For the all-in-one experience, use the [`make install`](#make-install--recommend
 **After upgrading**, restart any long-running daemon process so it picks up new D-Bus surface introduced by the upgrade. The CLI on `PATH` will be the new binary immediately, but the daemon process started by your session manager (or auto-activated by D-Bus before the upgrade) keeps running the old code until it exits. Quickest restart:
 
 ```bash
-kill $(pidof nwg-notifications)
+kill $(pidof nwg-notifications) 2>/dev/null || true
 # Your session manager (or D-Bus auto-activation on the next notify-send)
 # spawns the new binary. Or run `nwg-notifications --persist &` directly.
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Claims `org.freedesktop.Notifications`, shows popup toasts, and ships a slide-ou
 - **Rust 1.95** or later (pinned in `rust-toolchain.toml`; rustup picks it up automatically)
 - **GTK4** and **gtk4-layer-shell** system libraries
 - A Wayland compositor with `wlr-layer-shell` support (Hyprland, Sway)
+- A working **session D-Bus** (every Linux desktop has this — calling it out because nwg-notifications is fundamentally a D-Bus daemon: it claims `org.freedesktop.Notifications` on the session bus, so installing only the binary without registering a D-Bus service file means apps can't reach it)
 
 ### Install system dependencies
 
@@ -44,25 +45,7 @@ sudo apt install libgtk-4-dev libgtk4-layer-shell-dev
 sudo dnf install gtk4-devel gtk4-layer-shell-devel
 ```
 
-### From crates.io (recommended for end users)
-
-```bash
-cargo install nwg-notifications
-```
-
-Lands the binary at `~/.cargo/bin/nwg-notifications`. `cargo install` doesn't ship the D-Bus service file — you'll need to write that yourself (see [D-Bus service](#d-bus-service) below; it's a ~5-line file pointing at the installed binary). Once the service file is in place, the daemon auto-activates the first time any app calls `org.freedesktop.Notifications`.
-
-**After upgrading**, restart any long-running daemon process so it picks up new D-Bus surface introduced by the upgrade. The CLI on `PATH` will be the new binary immediately, but the daemon process started by your session manager (or auto-activated by D-Bus before the upgrade) keeps running the old code until it exits. Quickest restart:
-
-```bash
-kill $(pidof nwg-notifications)
-# Your session manager (or D-Bus auto-activation on the next notify-send)
-# spawns the new binary. Or run `nwg-notifications --persist &` directly.
-```
-
-Without this, `--update` and `gdbus call` against newly-shipped methods fail with `org.freedesktop.DBus.Error.UnknownMethod`.
-
-### `make install` — for source builds, distro packagers, and the `install-dbus` helper
+### `make install` — recommended (one-stop binary + D-Bus service file)
 
 The Makefile install path drops both the binary and the D-Bus service file (the latter always to user-scope, regardless of `PREFIX` — D-Bus user services are per-user by convention).
 
@@ -101,7 +84,27 @@ make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
 
 (Or `sudo make upgrade` for system-wide installs — same prefix matching applies.)
 
-This is the recommended path for the source-build workflow once the daemon is already running. Cargo-install users don't have it; see the "After upgrading" note in the [From crates.io](#from-cratesio-recommended-for-end-users) subsection above for the manual equivalent.
+This is the recommended path for the source-build workflow once the daemon is already running. Cargo-install users don't have it; see the "After upgrading" note in the [From crates.io](#from-cratesio--rust-toolchain-alternative) subsection below for the manual equivalent.
+
+### From crates.io — Rust-toolchain alternative
+
+```bash
+cargo install nwg-notifications
+```
+
+This is the right path if you prefer the Rust toolchain workflow over `make install`. **Heads-up: this is a two-step install** — `cargo install` only places the binary at `~/.cargo/bin/nwg-notifications`, it doesn't create the D-Bus service file the daemon needs to be reachable. After running the command above, manually create the service file (see [D-Bus service](#d-bus-service) below; it's a ~5-line file pointing at the installed binary). Once the service file is in place, the daemon auto-activates the first time any app calls `org.freedesktop.Notifications`.
+
+For the all-in-one experience, use the [`make install`](#make-install--recommended-one-stop-binary--d-bus-service-file) path above.
+
+**After upgrading**, restart any long-running daemon process so it picks up new D-Bus surface introduced by the upgrade. The CLI on `PATH` will be the new binary immediately, but the daemon process started by your session manager (or auto-activated by D-Bus before the upgrade) keeps running the old code until it exits. Quickest restart:
+
+```bash
+kill $(pidof nwg-notifications)
+# Your session manager (or D-Bus auto-activation on the next notify-send)
+# spawns the new binary. Or run `nwg-notifications --persist &` directly.
+```
+
+Without this, `--update` and `gdbus call` against newly-shipped methods fail with `org.freedesktop.DBus.Error.UnknownMethod`.
 
 ## Usage
 

--- a/docs/superpowers/plans/2026-05-03-actionable-update-error.md
+++ b/docs/superpowers/plans/2026-05-03-actionable-update-error.md
@@ -1,0 +1,419 @@
+# Actionable `--update` Error When Daemon Predates the Method Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `nwg-notifications --update` calls a D-Bus method the running daemon doesn't have (because the daemon is from a release older than the CLI), print an actionable error that names the missing method and suggests restarting the daemon, instead of bubbling the raw `GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod` to the user. Add a README paragraph reminding users to restart the daemon after upgrading the binary.
+
+**Architecture:** Add a small pure helper `dbus::is_unknown_method_error(&glib::Error) -> bool` that wraps `glib::Error::matches::<gio::DBusError>(gio::DBusError::UnknownMethod)` for unit-testability. Use it in `src/main.rs::main`'s `--update` error handler to branch on the error class: when `UnknownMethod` fires, print a multi-line actionable message (method name, "daemon may be older than this CLI", restart recipe). For all other error classes (no-such-name, timeout, payload type), keep the current generic format unchanged.
+
+**Tech Stack:** Rust, `gio::DBusError`, `glib::Error::matches`.
+
+**Tracks:** Closes [#25](https://github.com/jasonherald/nwg-notifications/issues/25). Surfaced from [OG's v0.3.2 testing on #2](https://github.com/jasonherald/nwg-notifications/issues/2#issuecomment-4350866611).
+
+---
+
+## File Structure
+
+- **Modify:** `src/dbus.rs` — add `pub fn is_unknown_method_error(err: &glib::Error) -> bool` next to the existing `push_*` client helpers; add a `#[cfg(test)] mod tests` block with two unit tests (positive case + negative case). The dbus.rs file already has its `unread_count_to_u32` test scaffolding from #9, so the test module pattern is established.
+- **Modify:** `src/main.rs` — extend the `--update` error handler to call `dbus::is_unknown_method_error(&e)` and print the actionable multi-line message when true. Other errors keep the current single-line `Failed to update X: <err>` format.
+- **Modify:** `CHANGELOG.md` — entry under `[0.3.4] — Unreleased` Fixed.
+- **Modify:** `README.md` — short note added near the existing install/upgrade content explaining the restart-after-upgrade requirement, citing the same `kill $(pidof nwg-notifications)` recipe.
+
+No new files. Helper lives in `dbus.rs` since it classifies errors that originate from D-Bus calls; same module as the `push_*` helpers that produce those errors.
+
+---
+
+## Pre-flight
+
+- [ ] **Sync main and create branch**
+
+```bash
+cd /data/source/nwg-notifications
+git checkout main && git pull --ff-only
+git status
+git checkout -b fix/actionable-update-error
+```
+
+Expected: clean tree on `main` synced to origin, then a fresh branch `fix/actionable-update-error`.
+
+- [ ] **Commit the plan file as the first commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-actionable-update-error.md
+git commit -m "docs: implementation plan for actionable --update error (#25)"
+```
+
+- [ ] **Baseline full cargo gambit**
+
+```bash
+make lint
+```
+
+Expected: every step exits 0; pre-existing `cargo deny` "unmatched skip" warnings are non-blocking.
+
+---
+
+## Task 1: Add `is_unknown_method_error` helper with TDD
+
+**Files:**
+- Modify: `src/dbus.rs` — new `pub fn` + tests in the existing `#[cfg(test)] mod tests` block.
+
+- [ ] **Step 1: Write failing tests**
+
+In `src/dbus.rs`, find the existing `#[cfg(test)] mod tests { ... }` block at the bottom. Append these tests:
+
+```rust
+    #[test]
+    fn is_unknown_method_error_recognises_dbus_unknown_method() {
+        let err = glib::Error::new(gio::DBusError::UnknownMethod, "method missing");
+        assert!(is_unknown_method_error(&err));
+    }
+
+    #[test]
+    fn is_unknown_method_error_rejects_other_dbus_errors() {
+        let err = glib::Error::new(gio::DBusError::NoMemory, "out of memory");
+        assert!(!is_unknown_method_error(&err));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cargo test is_unknown_method_error 2>&1 | tail -10
+```
+
+Expected: compile error — `is_unknown_method_error` doesn't exist yet.
+
+- [ ] **Step 3: Add the helper**
+
+Add this function to `src/dbus.rs`. Place it near the existing client helpers (after the `push_max_history` definition, before the `emit_count_changed` signal helper):
+
+```rust
+/// Returns true if the given `glib::Error` is the standard D-Bus
+/// `org.freedesktop.DBus.Error.UnknownMethod` error class. Used by the
+/// `--update` CLI to give an actionable message when the running daemon
+/// is from a release older than the CLI and doesn't recognise a method
+/// the CLI is trying to call (#25).
+pub fn is_unknown_method_error(err: &glib::Error) -> bool {
+    err.matches(gio::DBusError::UnknownMethod)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test is_unknown_method_error 2>&1 | tail -10
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Build, full test, clippy**
+
+```bash
+cargo build
+cargo test
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: clean. Test count grows by 2 (was 63, now 65).
+
+If clippy complains about `dead_code` for the new `pub fn` (because the bin crate has no consumer yet), the next task wires it in — leave the commit until Task 2 lands so the branch never has a clippy-broken intermediate. Mirror the pattern used in #20's PopupManager::dismiss_all_popups commit.
+
+- [ ] **Step 6: Hold the commit**
+
+Don't commit yet — wait for Task 2 to land the consumer. The combined commit from Task 2 makes the branch always-buildable under `-D warnings`.
+
+---
+
+## Task 2: Wire the actionable message in `--update`'s error handler
+
+**Files:**
+- Modify: `src/main.rs` — update the `--update` error path to branch on `is_unknown_method_error`.
+
+- [ ] **Step 1: Update the error handler**
+
+In `src/main.rs::main`, the current `--update` error path is:
+
+```rust
+            if let Err(e) = push_result {
+                eprintln!("Failed to update {}: {}", name, e);
+                had_error = true;
+            } else {
+                println!("Updated {}", name);
+            }
+```
+
+Replace it with:
+
+```rust
+            if let Err(e) = push_result {
+                if dbus::is_unknown_method_error(&e) {
+                    eprintln!(
+                        "Failed to update {name}: the running daemon doesn't recognise this D-Bus method.\n\
+                         This usually means the daemon is from a release older than this CLI.\n\
+                         Restart it to pick up the new methods, e.g.:\n  \
+                         kill $(pidof nwg-notifications)\n\
+                         and let your session manager respawn it (or just run `nwg-notifications --persist &` yourself).\n\
+                         Underlying error: {e}"
+                    );
+                } else {
+                    eprintln!("Failed to update {name}: {e}");
+                }
+                had_error = true;
+            } else {
+                println!("Updated {name}");
+            }
+```
+
+The actionable branch covers UnknownMethod specifically. All other error classes (no daemon owning the name, timeout, payload-type errors) keep their existing single-line format — those aren't usually about version mismatch and the restart hint would be misleading.
+
+- [ ] **Step 2: Build, full test, clippy**
+
+```bash
+cargo build
+cargo test
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: clean. The 65 tests still pass.
+
+- [ ] **Step 3: Commit Tasks 1 + 2 together**
+
+The two tasks form one coherent change — the helper and its consumer. Single commit keeps the branch always-buildable.
+
+```bash
+git add src/dbus.rs src/main.rs
+git commit -m "$(cat <<'EOF'
+Actionable error when --update hits UnknownMethod (#25)
+
+When --update calls a D-Bus method the running daemon doesn't have
+(typically because the daemon is from a release older than the CLI),
+the previous error path bubbled the raw GDBus.Error...UnknownMethod
+text — technically correct but not actionable. A user couldn't tell
+they needed to restart the daemon.
+
+Add a small pure helper dbus::is_unknown_method_error that wraps
+glib::Error::matches(gio::DBusError::UnknownMethod). Use it in main()'s
+--update error handler to print a multi-line actionable message naming
+the flag, explaining the likely cause (CLI is newer than daemon), and
+suggesting the kill+respawn recipe. Other error classes (no-such-name,
+timeout, payload type) keep the existing single-line format — the
+restart hint would mislead in those cases.
+
+2 new unit tests cover the predicate (positive case for UnknownMethod,
+negative case for a different DBusError). Test count: 63 -> 65.
+
+Closes #25.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Documentation
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md` — add a paragraph near the install/upgrade content.
+
+- [ ] **Step 1: CHANGELOG entry**
+
+The `CHANGELOG.md` currently has `## [0.3.3] — 2026-04-29` at the top of the version sections (after the pre-split note block). Add a new `## [0.3.4] — Unreleased` block above it:
+
+```markdown
+## [0.3.4] — Unreleased
+
+### Fixed
+
+- `--update` now prints an actionable error when it calls a D-Bus
+  method the running daemon doesn't recognise — typically because the
+  daemon is from a release older than the CLI. Previously the raw
+  `GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod` text bubbled
+  to the user, which didn't hint at the restart-after-upgrade fix.
+  Other error classes (no daemon, timeout, payload type) keep their
+  existing format. (#25)
+```
+
+(Place this above the `## [0.3.3] — 2026-04-29` section.)
+
+- [ ] **Step 2: README addition**
+
+Find the "From crates.io" install subsection in `README.md`. After its existing paragraph (the "Lands the binary at `~/.cargo/bin/nwg-notifications` ..." block), append a new paragraph:
+
+````markdown
+**After upgrading**, restart any long-running daemon process so it picks up new D-Bus surface introduced by the upgrade. The CLI on `PATH` will be the new binary immediately, but the daemon process started by your session manager (or auto-activated by D-Bus before the upgrade) keeps running the old code until it exits. Quickest restart:
+
+```bash
+kill $(pidof nwg-notifications)
+# Your session manager (or D-Bus auto-activation on the next notify-send)
+# spawns the new binary. Or run `nwg-notifications --persist &` directly.
+```
+
+Without this, `--update` and `gdbus call` against newly-shipped methods fail with `org.freedesktop.DBus.Error.UnknownMethod`.
+````
+
+(Same restart recipe applies to anyone using `make install` — the principle is "after replacing the binary, restart the daemon process." The README's `make install` subsections don't need a separate copy of this note since the principle is the same.)
+
+- [ ] **Step 3: Build, test, clippy sanity**
+
+```bash
+cargo build && cargo test && cargo clippy --all-targets -- -D warnings
+```
+
+Expected: clean (CHANGELOG + README don't compile, but running these confirms nothing else slipped).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "$(cat <<'EOF'
+docs: actionable --update error + restart-after-upgrade note (#25)
+
+CHANGELOG entry under new [0.3.4] — Unreleased Fixed section.
+
+README "From crates.io" subsection grows a paragraph explaining that
+after upgrading the binary, any long-running daemon process needs to
+restart so it picks up new D-Bus surface — otherwise --update and
+gdbus call against newly-shipped methods hit UnknownMethod. Cites
+the same kill-and-respawn recipe the new --update error message uses.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: User smoke-test gate (HARD STOP)
+
+The unit tests cover the predicate; manual verification confirms the actual error text in both branches against a real daemon.
+
+- [ ] **Step 1: Install to the user's `~/.cargo/bin`**
+
+```bash
+make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+- [ ] **Step 2: Restart the user's session daemon so it has the new binary**
+
+```bash
+kill $(pidof nwg-notifications) 2>/dev/null || true
+sleep 0.5
+uwsm-app -- nwg-notifications --persist >/dev/null 2>&1 &
+disown
+sleep 1
+pidof nwg-notifications && echo "(daemon up)"
+```
+
+- [ ] **Step 3: Hand off to the user — STOP HERE**
+
+Tell the user (verbatim or close):
+> Installed and restarted the daemon. Smoke-test paths for #25:
+>
+> 1. **Happy path still works (regression check):**
+>    - `nwg-notifications --update --popup-position top-center` → expect `Updated popup_position`, exit 0.
+>    - `notify-send "test" "msg"` → popup at top-center.
+>
+> 2. **Trigger the new actionable error path.** Easiest reliable way is to call a method that doesn't exist via `gdbus`:
+>    - `gdbus call --session --dest org.nwg.Notifications --object-path /org/nwg/Notifications --method org.nwg.Notifications.SetNonexistentMethod 42` → expect raw `UnknownMethod` from gdbus (this confirms the daemon's dispatcher returns it; we already shipped that).
+>
+>    To exercise the *CLI* error path against the same condition, we'd need an old-binary daemon — most reliable repro is to ask OG to test against his old daemon, or to temporarily run the previous-release binary as the daemon while invoking the new `--update`. Skip if you'd rather just trust the unit tests for the predicate; the message wording is straightforward to eyeball in `src/main.rs`.
+>
+> 3. **Other error classes still use the generic format (no actionable hint):**
+>    - `kill $(pidof nwg-notifications) 2>/dev/null` → daemon stops.
+>    - `nwg-notifications --update --popup-position top-center` → expect `Failed to update popup_position: <NoSuchName error>` *without* the multi-line restart hint (because this is a no-daemon error, not UnknownMethod).
+>    - Restart back to default: `uwsm-app -- nwg-notifications --persist >/dev/null 2>&1 & disown`
+>
+> 4. **README reads cleanly:**
+>    - `cat README.md | grep -A12 "After upgrading"` → confirm the new paragraph reads well in the install context.
+>
+> Reply when satisfied or with anything that needs fixing.
+
+**Do not proceed to Task 5 until the user explicitly approves.** If they report issues, return to the broken task.
+
+---
+
+## Task 5: Full cargo gambit (CI parity)
+
+- [ ] **Step 1: `make lint`**
+
+```bash
+make lint
+```
+
+If `cargo fmt --check` reformats anything, run `cargo fmt --all`, commit as `style: cargo fmt`, re-run `make lint`. Stop on new deny/audit findings.
+
+- [ ] **Step 2: Confirm clean working tree**
+
+```bash
+git status
+```
+
+Expected: clean.
+
+---
+
+## Task 6: Open the PR
+
+Gated on Task 4 (user smoke-test approval) AND Task 5 (clean `make lint`).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/actionable-update-error
+```
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+gh pr create --title "Actionable --update error when daemon predates the called method (#25)" --body "$(cat <<'EOF'
+## Summary
+
+Surfaced from [OG's v0.3.2 testing on #2](https://github.com/jasonherald/nwg-notifications/issues/2#issuecomment-4350866611): when his CLI was on ≥0.3.2 (with \`--update\`) but his running daemon was still on an older release, \`nwg-notifications --update --popup-position top-center\` failed with the raw \`GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod\` text. Technically correct, but not actionable — a user reading "method missing" can't tell they need to restart the daemon.
+
+This PR has two pieces:
+
+1. **CLI error message.** \`--update\` now detects \`UnknownMethod\` errors specifically and prints a multi-line actionable message naming the flag, explaining the likely cause, and suggesting the \`kill $(pidof nwg-notifications)\` recipe. Other error classes (no daemon at all, timeouts, payload-type mismatches) keep their existing single-line format — the restart hint would mislead in those cases.
+2. **README addition.** New paragraph under the "From crates.io" install subsection explaining that after upgrading the binary, any long-running daemon process needs to restart so it picks up new D-Bus surface.
+
+The same restart-after-upgrade principle applies to anyone using \`make install\` too; the README's principle paragraph is single-source under the crates.io subsection rather than copy-pasted across each install variant.
+
+Closes #25.
+
+## Test plan
+
+- [x] \`make lint\` — fmt + clippy + test + deny + audit, all green locally.
+- [x] 2 new unit tests for \`dbus::is_unknown_method_error\` (positive case for \`UnknownMethod\`, negative case for a different \`DBusError\` variant). Test count: 63 → 65.
+- [x] Manual smoke test against the live compositor:
+  - [x] Happy path: \`--update --popup-position top-center\` against a current-version daemon still works (\`Updated popup_position\`, exit 0).
+  - [x] Other error classes: with no daemon running, \`--update\` shows the *existing* generic single-line format (no spurious restart hint).
+  - [x] README's new paragraph reads cleanly in the install section.
+  - [x] The new actionable-message branch is hard to repro against a current-version daemon end-to-end (you'd need to run a deliberately-old daemon while invoking the new CLI). Predicate is unit-tested; the message wording is small enough to eyeball.
+
+## Notes
+
+- A richer error-classification helper (e.g. an enum covering \`NoSuchName\`, \`Timeout\`, \`UnknownMethod\`, etc.) was considered and skipped — YAGNI for this PR. If we end up needing per-class messages for more failure modes later, expand then.
+- D-Bus integration tests (#16) would let us exercise the actionable-message branch end-to-end. That work is parked pending the broader nwg-* integration-testing infrastructure initiative.
+
+The implementation plan (committed as \`docs/superpowers/plans/2026-05-03-actionable-update-error.md\`) is on the branch for reviewer context.
+EOF
+)"
+```
+
+Expected: returns the PR URL.
+
+- [ ] **Step 3: Hand off to CodeRabbit**
+
+CodeRabbit reviews within minutes. **Default to fixing every finding in-PR.** Defer only when the fix needs new infrastructure or has wide blast radius — and when you do defer, open a tracking issue *first*. Reply protocol: inline replies for in-diff comments, single PR-level comment for outside-diff items, tag `@coderabbitai` every time so it learns from the responses.
+
+---
+
+## Acceptance checklist (cross-reference to issue #25)
+
+- [ ] `--update` failures whose underlying `glib::Error` is `UnknownMethod` print an actionable message including the suggested restart command. — Task 2 (with helper from Task 1)
+- [ ] Other failure classes (no daemon owning the name, timeout, payload-type errors) still surface their current generic message. — Task 2 (else-branch unchanged from existing `eprintln!`)
+- [ ] README has a paragraph under the install/upgrade section about restart-after-upgrade. — Task 3
+- [ ] Unit test for the new error-classification helper. — Task 1 (2 tests)
+- [ ] CHANGELOG entry under unreleased Fixed. — Task 3

--- a/docs/superpowers/plans/2026-05-03-actionable-update-error.md
+++ b/docs/superpowers/plans/2026-05-03-actionable-update-error.md
@@ -246,7 +246,7 @@ Find the "From crates.io" install subsection in `README.md`. After its existing 
 **After upgrading**, restart any long-running daemon process so it picks up new D-Bus surface introduced by the upgrade. The CLI on `PATH` will be the new binary immediately, but the daemon process started by your session manager (or auto-activated by D-Bus before the upgrade) keeps running the old code until it exits. Quickest restart:
 
 ```bash
-kill $(pidof nwg-notifications)
+kill $(pidof nwg-notifications) 2>/dev/null || true
 # Your session manager (or D-Bus auto-activation on the next notify-send)
 # spawns the new binary. Or run `nwg-notifications --persist &` directly.
 ```
@@ -322,7 +322,7 @@ Tell the user (verbatim or close):
 >    To exercise the *CLI* error path against the same condition, we'd need an old-binary daemon — most reliable repro is to ask OG to test against his old daemon, or to temporarily run the previous-release binary as the daemon while invoking the new `--update`. Skip if you'd rather just trust the unit tests for the predicate; the message wording is straightforward to eyeball in `src/main.rs`.
 >
 > 3. **Other error classes still use the generic format (no actionable hint):**
->    - `kill $(pidof nwg-notifications) 2>/dev/null` → daemon stops.
+>    - `kill $(pidof nwg-notifications) 2>/dev/null || true` → daemon stops.
 >    - `nwg-notifications --update --popup-position top-center` → expect `Failed to update popup_position: <NoSuchName error>` *without* the multi-line restart hint (because this is a no-daemon error, not UnknownMethod).
 >    - Restart back to default: `uwsm-app -- nwg-notifications --persist >/dev/null 2>&1 & disown`
 >

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -623,6 +623,15 @@ pub fn push_max_history(value: u32) -> Result<(), glib::Error> {
     call_setter_sync("SetMaxHistory", glib::Variant::from((value,)))
 }
 
+/// Returns true if the given `glib::Error` is the standard D-Bus
+/// `org.freedesktop.DBus.Error.UnknownMethod` error class. Used by the
+/// `--update` CLI to give an actionable message when the running daemon
+/// is from a release older than the CLI and doesn't recognise a method
+/// the CLI is trying to call (#25).
+pub fn is_unknown_method_error(err: &glib::Error) -> bool {
+    err.matches(gio::DBusError::UnknownMethod)
+}
+
 /// Emits CountChanged on the org.nwg.Notifications interface.
 ///
 /// Best-effort: a failure here doesn't affect anything else; we log and move on.
@@ -691,5 +700,17 @@ mod tests {
     fn unread_count_to_u32_clamps_on_overflow() {
         assert_eq!(unread_count_to_u32(u32::MAX as usize + 1), u32::MAX);
         assert_eq!(unread_count_to_u32(usize::MAX), u32::MAX);
+    }
+
+    #[test]
+    fn is_unknown_method_error_recognises_dbus_unknown_method() {
+        let err = glib::Error::new(gio::DBusError::UnknownMethod, "method missing");
+        assert!(is_unknown_method_error(&err));
+    }
+
+    #[test]
+    fn is_unknown_method_error_rejects_other_dbus_errors() {
+        let err = glib::Error::new(gio::DBusError::NoMemory, "out of memory");
+        assert!(!is_unknown_method_error(&err));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
                         "Failed to update {name}: the running daemon doesn't recognise this D-Bus method.\n\
                          This usually means the daemon is from a release older than this CLI.\n\
                          Restart it to pick up the new methods, e.g.:\n  \
-                         kill $(pidof nwg-notifications)\n\
+                         kill $(pidof nwg-notifications) 2>/dev/null || true\n\
                          and let your session manager respawn it (or just run `nwg-notifications --persist &` yourself).\n\
                          Underlying error: {e}"
                     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,10 +71,21 @@ fn main() {
                 _ => unreachable!("user_set_live_args returns only known names"),
             };
             if let Err(e) = push_result {
-                eprintln!("Failed to update {}: {}", name, e);
+                if dbus::is_unknown_method_error(&e) {
+                    eprintln!(
+                        "Failed to update {name}: the running daemon doesn't recognise this D-Bus method.\n\
+                         This usually means the daemon is from a release older than this CLI.\n\
+                         Restart it to pick up the new methods, e.g.:\n  \
+                         kill $(pidof nwg-notifications)\n\
+                         and let your session manager respawn it (or just run `nwg-notifications --persist &` yourself).\n\
+                         Underlying error: {e}"
+                    );
+                } else {
+                    eprintln!("Failed to update {name}: {e}");
+                }
                 had_error = true;
             } else {
-                println!("Updated {}", name);
+                println!("Updated {name}");
             }
         }
         std::process::exit(if had_error { 1 } else { 0 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,17 @@ fn main() {
     let config = NotificationConfig::from_arg_matches(&matches)
         .expect("clap should produce a valid NotificationConfig from successful matches");
 
+    // Initialize logging before any early-exit CLI mode (--count, --update) so
+    // their error paths can reach log::error! per the project's "log errors"
+    // convention. Idempotent here — daemon mode reads the same config.debug.
+    if config.debug {
+        env_logger::Builder::from_default_env()
+            .filter_level(log::LevelFilter::Debug)
+            .init();
+    } else {
+        env_logger::init();
+    }
+
     if config.count {
         match dbus::query_count_via_dbus() {
             Ok(count) => {
@@ -35,6 +46,7 @@ fn main() {
                 std::process::exit(0);
             }
             Err(e) => {
+                log::error!("Failed to query count: {}", e);
                 eprintln!("Failed to query count: {}", e);
                 eprintln!("(is the nwg-notifications daemon running?)");
                 std::process::exit(1);
@@ -72,6 +84,11 @@ fn main() {
             };
             if let Err(e) = push_result {
                 if dbus::is_unknown_method_error(&e) {
+                    log::error!(
+                        "Failed to update {} (unknown D-Bus method on running daemon): {}",
+                        name,
+                        e
+                    );
                     eprintln!(
                         "Failed to update {name}: the running daemon doesn't recognise this D-Bus method.\n\
                          This usually means the daemon is from a release older than this CLI.\n\
@@ -81,6 +98,7 @@ fn main() {
                          Underlying error: {e}"
                     );
                 } else {
+                    log::error!("Failed to update {}: {}", name, e);
                     eprintln!("Failed to update {name}: {e}");
                 }
                 had_error = true;
@@ -89,14 +107,6 @@ fn main() {
             }
         }
         std::process::exit(if had_error { 1 } else { 0 });
-    }
-
-    if config.debug {
-        env_logger::Builder::from_default_env()
-            .filter_level(log::LevelFilter::Debug)
-            .init();
-    } else {
-        env_logger::init();
     }
 
     let _lock = match singleton::acquire_lock("mac-notifications") {


### PR DESCRIPTION
## Summary

Surfaced from [OG's v0.3.2 testing on #2](https://github.com/jasonherald/nwg-notifications/issues/2#issuecomment-4350866611): \`nwg-notifications --update --popup-position top-center\` against an older daemon failed with raw \`GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod\` text — technically correct, but a user reading "method missing" can't tell they need to restart the daemon.

This PR has two parts (one CLI, one docs) bundled together because they're the same diagnostic story:

### CLI (\`src/dbus.rs\`, \`src/main.rs\`)

- New \`pub fn dbus::is_unknown_method_error(err: &glib::Error) -> bool\` — wraps \`err.matches(gio::DBusError::UnknownMethod)\`.
- \`--update\`'s error handler in \`main()\` now branches on the predicate. UnknownMethod fires a multi-line actionable message naming the flag, the likely cause (CLI is newer than daemon), and the \`kill $(pidof nwg-notifications)\` restart recipe. Other error classes (no daemon, timeout, payload type) keep their existing single-line format.
- 2 new unit tests (positive + negative). Test count: 63 → 65.

### Docs (\`CHANGELOG.md\`, \`README.md\`)

- CHANGELOG entry under new \`## [0.3.4] — Unreleased\` Fixed.
- **Install section rebalance** — surfaced while writing the README addition: the previous "From crates.io (recommended for end users)" framing oversold the cargo-install path (it's actually a two-step install — binary + manual D-Bus service file). Three rebalances:
  - Added a "session D-Bus" bullet to Requirements so the daemon's hard dependency is upfront.
  - Promoted \`make install + make install-dbus\` to the lead position as the one-stop install.
  - Reframed the cargo-install subsection as the "Rust-toolchain alternative" with an explicit "**Heads-up: this is a two-step install**" warning before the \`cargo install\` example.
- **\`make upgrade\` callout** — the Makefile already had a \`make upgrade\` target that does build + install + daemon restart in one go (validates prefix match, captures running args via \`--dump-args\`, SIGTERMs, installs, respawns). The README never mentioned it. Now it's documented under the \`make install\` subsection with the dev/test recipe (\`make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin\`) called out — same recipe we use to dogfood every PR. Cargo-install users with a source clone available now get a cross-link to it.

A future curl-based installer is planned but out of scope for this PR.

Closes #25.

## Test plan

- [x] \`make lint\` — fmt + clippy + test + deny + audit, all green locally.
- [x] 2 new unit tests for \`dbus::is_unknown_method_error\` (positive case for \`UnknownMethod\`, negative case for a different \`DBusError\` variant). Test count: 63 → 65.
- [x] Manual smoke test against the live compositor:
  - [x] Happy path: \`--update --popup-position top-center\` against current-version daemon works (\`Updated popup_position\`, exit 0).
  - [x] Other error classes: with no daemon running, \`--update\` shows the existing generic single-line format (no spurious restart hint).
  - [x] README renders cleanly in the install section after rebalance; both internal anchor links resolve.
- [x] Verified \`make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin\` end-to-end against this branch's binary: built release, validated install target, SIGTERMed old daemon, captured \`--persist\` args via \`--dump-args\`, installed new binary, respawned with same args. Then \`nwg-notifications --update --popup-position top-center\` worked against the upgraded daemon.

## Notes

- A richer error-classification helper (e.g. an enum covering NoSuchName, Timeout, UnknownMethod, etc.) was considered and skipped — YAGNI for this PR.
- D-Bus integration tests (#16) would let us exercise the actionable-message branch end-to-end. Parked pending the broader nwg-* integration-testing infrastructure initiative.
- Subagent-driven development workflow used for this PR — implementer + spec reviewer + code quality reviewer per task. Spec reviewer caught a fence-style nit in the initial docs commit (quadruple-vs-triple bash backticks); fixed in commit \`3383741\` before code review.

The implementation plan (committed as \`docs/superpowers/plans/2026-05-03-actionable-update-error.md\`) is on the branch for reviewer context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `--update` now shows a clear, user-actionable message when the running daemon doesn’t support the requested D-Bus method, advising restart/respawn and including the underlying error; count-query failures also emit clearer error logs and update success/failure messages behave more consistently.

* **Documentation**
  * Expanded installation and upgrade guidance (recommended make install/upgrade path), added restart/troubleshooting and after-upgrade notes, and documented the UnknownMethod failure mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->