### PR TITLE
Release 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
-## [0.3.4] — Unreleased
+## [0.3.4] — 2026-05-03
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-notifications"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-notifications"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release prep for crates.io publish:

- **Cargo.toml**: bumps version 0.3.3 → 0.3.4.
- **CHANGELOG**: promotes \`[0.3.4] — Unreleased\` → \`[0.3.4] — 2026-05-03\`.

0.3.4 ships:
- The actionable \`--update\` UnknownMethod error fix (#25) — when the CLI is newer than the running daemon, \`--update\` now hints at restart-after-upgrade rather than bubbling raw \`GDBus.Error...UnknownMethod\` text.
- README install-section rebalance — \`make install\` is now the lead one-stop path, \`cargo install\` reframed as the Rust-toolchain alternative with an explicit two-step heads-up.
- \`make upgrade\` promoted to its own H3 subsection with the dev/test recipe \`make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin\` highlighted.
- CLI short-circuit modes (\`--count\`, \`--update\`) now log errors via \`log::error!\` per project convention; \`env_logger::init()\` moved earlier so those branches actually reach the logger.
- New session-D-Bus bullet in Requirements (sets the daemon expectation upfront).

Patch-level bump per SemVer 0.x — no API changes.

## Test plan

- [x] \`make lint\` — fmt + clippy + test + deny + audit, all green locally.
- [x] All 65 unit tests pass against version 0.3.4.

## After merge

- Pull main, tag \`v0.3.4\`, push tag.
- \`cargo publish --dry-run\` to validate.
- \`cargo publish\` for real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `--update` flag now displays more actionable error messages when the daemon rejects the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->