### PR TITLE
Bundle four post-v0.3.4 correctness bugs (#30 #31 #32 #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
+## [0.3.5] — Unreleased
+
+### Fixed
+
+- Four post-v0.3.4 correctness bugs surfaced by the comprehensive
+  code-quality review (epic #29):
+  - `--update --max-history N` now actually changes the trim cap
+    instead of waiting for daemon restart. `trim_history()` reads
+    `max_history` from the live config rather than a state-side copy
+    seeded once at startup. (#30)
+  - Re-clicking a different timed-DND duration before the first
+    timer fires no longer leaves the older one armed and clearing
+    DND early. Each scheduled timer now captures its expiry as a
+    token and no-ops silently if the live expiry has been replaced
+    by a newer schedule. (#31)
+  - `org.freedesktop.Notifications.GetServerInformation` now returns
+    the real vendor (`nwg-notifications`) and version (from
+    `CARGO_PKG_VERSION`). Previously reported vendor
+    `nwg-dock-hyprland` and version `0.1.0` — both pre-split
+    monorepo leftovers visible to any client app or notification
+    debugger. (#32)
+  - Waybar refresh signal is now computed from `libc::SIGRTMIN()` at
+    runtime instead of hardcoded to 45 (which was wrong on musl,
+    where `SIGRTMIN+11 = 46`). musl users were silently sending the
+    wrong signal to waybar. (#33)
+
 ## [0.3.4] — 2026-05-03
 
 ### Fixed

--- a/docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md
+++ b/docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md
@@ -1,0 +1,826 @@
+# Bundled Correctness Bug Fixes (#30, #31, #32, #33) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bundle the four post-v0.3.4 correctness bug fixes (#30, #31, #32, #33 — all four "ship first" items from the polish-pass review) into one PR, smallest-to-largest, each in its own commit. Bundled because we're outrunning CodeRabbit's review capacity and these four are the most user-visible bugs surfaced by the comprehensive review.
+
+**Architecture:** Each fix is contained in 1–3 source files and follows the established codebase patterns. #32 extracts the server-info tuple into a pure helper for testability. #33 replaces the hardcoded signal number with a runtime `libc::SIGRTMIN()`-based lookup (mirrors what `nwg-common::signals::sigrtmin` does internally — we don't add a public helper to nwg-common in this PR because the existing fn is private and the cross-repo PR + crates.io publish is too much for a "ship now" bundle; track separately under #33's `nwg-common-candidate` label as a follow-up). #31 fixes the timed-DND timer by stamping each scheduled timeout with its captured `SystemTime` expiry as a generation token; the timer no-ops if the stored expiry has been replaced by a newer schedule. #30 removes the duplicated `max_history` field from `NotificationState`, threading a `Rc<RefCell<NotificationConfig>>` through state construction so `trim_history()` reads the live value (matches the existing precedent for `dbus_connection: Option<gio::DBusConnection>` on the same struct).
+
+**Tech Stack:** Rust, gtk4 (gio + glib), `libc::SIGRTMIN()`, existing `Rc<RefCell<>>` shared-state pattern.
+
+**Tracks:** Closes #30, #31, #32, #33. All four are children of epic #29 (post-v0.3.4 polish pass).
+
+---
+
+## File Structure
+
+| Task | Files modified | Test approach |
+|------|---------------|---------------|
+| #32 GetServerInformation | `src/dbus.rs` (extract pure helper + 1 test) | Unit test on the helper |
+| #33 WAYBAR_REFRESH_SIGNAL | `src/waybar.rs` | Smoke test only (signal delivery) |
+| #31 timed-DND cancel | `src/ui/dnd_menu.rs` | Smoke test only (GTK timer) |
+| #30 max_history sync | `src/state.rs`, `src/main.rs`, `src/ui/dnd_menu.rs` (any callers of `NotificationState::new`) | Existing `trim_history_caps_at_max` test updated; new test for `--update --max-history` semantics |
+
+Each fix is a single commit. CHANGELOG entry is one combined Fixed bullet referencing all four issues. No new files.
+
+---
+
+## Pre-flight
+
+- [ ] **Sync main and create branch**
+
+```bash
+cd /data/source/nwg-notifications
+git checkout main && git pull --ff-only
+git status
+git checkout -b fix/bundled-bugs-30-31-32-33
+```
+
+Expected: clean tree on `main`, then a fresh branch.
+
+- [ ] **Commit the plan file as the first commit on the branch**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md
+git commit -m "docs: implementation plan for bundled bug fixes (#30 #31 #32 #33)"
+```
+
+- [ ] **Baseline full cargo gambit**
+
+```bash
+make lint
+```
+
+Expected: every step exits 0; pre-existing `cargo deny` "unmatched skip" warnings are non-blocking.
+
+---
+
+## Task 1: #32 — Fix `GetServerInformation` to report real name/vendor/version
+
+Smallest fix, lands first.
+
+**Files:**
+- Modify: `src/dbus.rs` — extract a `server_info_tuple()` pure helper, change `handle_server_info` to call it, add a unit test asserting the version comes from `CARGO_PKG_VERSION`.
+
+- [ ] **Step 1: Locate the current `handle_server_info`**
+
+```bash
+grep -n 'fn handle_server_info' src/dbus.rs
+```
+
+Expected: one match. The current body returns the tuple `("nwg-notifications", "nwg-dock-hyprland", "0.1.0", "1.2")` — that's the bug.
+
+- [ ] **Step 2: Extract the tuple into a testable helper**
+
+Add this helper near `handle_server_info` in `src/dbus.rs`:
+
+```rust
+/// Returns the (name, vendor, version, spec_version) tuple reported by the
+/// `org.freedesktop.Notifications.GetServerInformation` D-Bus method.
+/// Vendor is the daemon's own name (single-vendor project convention);
+/// version comes from `Cargo.toml` at compile time so it stays in sync
+/// with releases automatically; spec_version tracks the freedesktop
+/// notification specification level we implement.
+fn server_info_tuple() -> (&'static str, &'static str, &'static str, &'static str) {
+    ("nwg-notifications", "nwg-notifications", env!("CARGO_PKG_VERSION"), "1.2")
+}
+```
+
+Then change `handle_server_info` to use it:
+
+```rust
+fn handle_server_info(invocation: gio::DBusMethodInvocation) {
+    let info = server_info_tuple();
+    let variant = glib::Variant::from(info);
+    invocation.return_value(Some(&variant));
+}
+```
+
+- [ ] **Step 3: Add a unit test**
+
+In the existing `#[cfg(test)] mod tests` block at the bottom of `src/dbus.rs`, append:
+
+```rust
+    #[test]
+    fn server_info_tuple_uses_cargo_pkg_version() {
+        let (name, vendor, version, spec) = server_info_tuple();
+        assert_eq!(name, "nwg-notifications");
+        assert_eq!(vendor, "nwg-notifications");
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(spec, "1.2");
+    }
+```
+
+- [ ] **Step 4: Build, test, clippy**
+
+```bash
+cargo build
+cargo test server_info
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: 1 new test passes; full test suite still green; clippy clean. Test count: 65 → 66.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dbus.rs
+git commit -m "$(cat <<'EOF'
+Fix GetServerInformation to report the real name/vendor/version (#32)
+
+handle_server_info returned ("nwg-notifications", "nwg-dock-hyprland",
+"0.1.0", "1.2") — vendor was a pre-split monorepo leftover, version
+was stale (we're on 0.3.4). Spec-visible misinformation that any
+client app or notification debugger introspecting the daemon would
+see.
+
+Extract the tuple into a pure server_info_tuple() helper that uses
+env!("CARGO_PKG_VERSION") so version stays in sync with Cargo.toml on
+every release. Vendor is the daemon's own name per the single-vendor
+project convention.
+
+1 new unit test (test count: 65 -> 66).
+
+Closes #32.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: #33 — Replace hardcoded `WAYBAR_REFRESH_SIGNAL: i32 = 45` with runtime SIGRTMIN
+
+**Files:**
+- Modify: `src/waybar.rs` — replace the `const` with a runtime computation; extract a small testable helper.
+
+**Note:** The original review item proposed adding a `pub fn sig_waybar_refresh()` to `nwg-common::signals`, but that crate's `sigrtmin()` is currently private and adding a public helper is a cross-repo PR + crates.io publish. Out of scope for this "ship now" bundle. Compute `libc::SIGRTMIN() + 11` directly in `waybar.rs` — same source-of-truth as `nwg-common`'s internal `sigrtmin()` function (which is itself just `libc::SIGRTMIN()`). Track the nwg-common promotion as a follow-up under #33's existing `nwg-common-candidate` label.
+
+- [ ] **Step 1: Replace the const with a function**
+
+In `src/waybar.rs`, remove the line:
+
+```rust
+/// Waybar refresh signal: SIGRTMIN+11 = 34+11 = 45.
+const WAYBAR_REFRESH_SIGNAL: i32 = 45;
+```
+
+Add this helper in its place (near the top, just after the imports):
+
+```rust
+/// Returns the runtime signal number for the waybar refresh signal
+/// (SIGRTMIN+11). Computed from `libc::SIGRTMIN()` rather than hardcoded
+/// because the value differs across libc implementations: glibc reserves
+/// the first two RT signals (so `SIGRTMIN` = 34, hence SIGRTMIN+11 = 45),
+/// while musl reserves three (so `SIGRTMIN` = 35, hence SIGRTMIN+11 = 46).
+/// The nwg-common crate uses the same `libc::SIGRTMIN()` lookup
+/// internally; we duplicate the call here rather than depend on a
+/// (currently private) helper there. See #33.
+fn waybar_refresh_signal() -> i32 {
+    libc::SIGRTMIN() + 11
+}
+```
+
+Update `signal_waybar` to call the helper:
+
+```rust
+/// Sends SIGRTMIN+11 to waybar to refresh the notification module.
+fn signal_waybar() {
+    let signal_num = waybar_refresh_signal();
+    match std::process::Command::new("pkill")
+        .arg(format!("-{signal_num}"))
+        .arg("waybar")
+        .status()
+    {
+        Err(e) => log::debug!("Failed to signal waybar: {e}"),
+        Ok(s) if !s.success() => log::debug!("No waybar process to signal"),
+        _ => {}
+    }
+}
+```
+
+- [ ] **Step 2: Add a unit test for the helper**
+
+In `src/waybar.rs`'s `#[cfg(test)] mod tests` block, append:
+
+```rust
+    #[test]
+    fn waybar_refresh_signal_is_sigrtmin_plus_11() {
+        let s = waybar_refresh_signal();
+        let base = libc::SIGRTMIN();
+        assert_eq!(s, base + 11, "expected SIGRTMIN({base}) + 11, got {s}");
+        // Cross-check that the value is in the RT-signal range. SIGRTMIN
+        // is at minimum 33 on Linux; SIGRTMAX is at most 64. SIGRTMIN+11
+        // must fit comfortably below SIGRTMAX even on the more
+        // restrictive musl layout.
+        assert!(s < libc::SIGRTMAX(), "signal {s} exceeds SIGRTMAX");
+    }
+```
+
+- [ ] **Step 3: Build, test, clippy**
+
+```bash
+cargo build
+cargo test waybar
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: 1 new test passes (test count: 66 → 67); existing `status_json_includes_count_field` still green; clippy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/waybar.rs
+git commit -m "$(cat <<'EOF'
+Compute WAYBAR_REFRESH_SIGNAL from libc::SIGRTMIN() at runtime (#33)
+
+The previous hardcoded const WAYBAR_REFRESH_SIGNAL: i32 = 45 worked
+on glibc (SIGRTMIN=34, +11=45) but was wrong on musl (SIGRTMIN=35,
++11=46) — exactly the gotcha CLAUDE.md flags ("Values approximate —
+glibc/musl differ; see nwg_common::signals::sigrtmin()"). Musl users
+were silently sending the wrong signal to waybar.
+
+Replace with a waybar_refresh_signal() helper that calls
+libc::SIGRTMIN() + 11 — same source-of-truth nwg-common uses
+internally for its sig_notification_* helpers. We don't add a public
+helper to nwg-common in this PR (that's a cross-repo publish) but
+the nwg-common-candidate label on #33 tracks the eventual promotion.
+
+1 new unit test asserting the helper returns SIGRTMIN+11 and stays
+below SIGRTMAX (test count: 66 -> 67).
+
+Closes #33.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: #31 — Cancel previous timed-DND timer when scheduling a new one
+
+**Files:**
+- Modify: `src/ui/dnd_menu.rs` — change `build_timed_dnd_button` to capture the scheduled expiry as a token and only act if the live `dnd_expires` still matches.
+
+**Approach:** Token-based via the existing `dnd_expires: Option<SystemTime>` field on `NotificationState`. Each scheduled timer captures the expiry it set; when the timer fires, it compares the current `dnd_expires` against its captured value and only fires if they still match. If the user has clicked a different duration in the meantime, the new schedule replaced the stored expiry, so the older timer no-ops silently. Simpler than tracking `glib::SourceId` (no removal logic needed; old timers harmlessly fire-and-no-op).
+
+- [ ] **Step 1: Update `build_timed_dnd_button`'s click handler**
+
+In `src/ui/dnd_menu.rs`, find the `connect_clicked` block inside `build_timed_dnd_button`. Replace the timer-scheduling section so it captures the expiry as a token:
+
+```rust
+    btn.connect_clicked(move |_| {
+        state_btn.borrow_mut().dnd = true;
+        let expiry = std::time::SystemTime::now() + std::time::Duration::from_secs(minutes * 60);
+        state_btn.borrow_mut().dnd_expires = Some(expiry);
+        log::info!("DND enabled for {} minutes", minutes);
+
+        // Capture the expiry we just stored. If the user clicks a
+        // different duration before this timer fires, the stored
+        // expiry will have been replaced; this timer's `expiry` token
+        // won't match and the firing will no-op. Cleaner than
+        // tracking a glib::SourceId and removing the previous source
+        // (no removal lifetime concerns).
+        let captured_expiry = expiry;
+        let state_timer = Rc::clone(&state_btn);
+        let on_change_timer = Rc::clone(&on_change);
+        gtk4::glib::timeout_add_local_once(
+            std::time::Duration::from_secs(minutes * 60),
+            move || {
+                let current = state_timer.borrow().dnd_expires;
+                if current == Some(captured_expiry) {
+                    state_timer.borrow_mut().dnd = false;
+                    state_timer.borrow_mut().dnd_expires = None;
+                    log::info!("Timed DND expired");
+                    on_change_timer();
+                }
+                // else: a newer schedule replaced this one; no-op silently.
+            },
+        );
+
+        on_change();
+        win_btn.set_visible(false);
+        for b in &backdrops_btn {
+            b.set_visible(false);
+        }
+    });
+```
+
+The change is surgical: we capture `expiry` into a separate `captured_expiry` binding (could just be `expiry` directly since it's `Copy` for `SystemTime`, but the named binding makes the token semantics explicit), and we change the `if state_timer.borrow().dnd_expires.is_some()` check to `if current == Some(captured_expiry)`.
+
+- [ ] **Step 2: Build, test, clippy**
+
+```bash
+cargo build
+cargo test
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: clean. No new tests — GTK timers aren't unit-testable from inside an isolated `#[test]`. Smoke test (Task 5 below) covers the user-visible behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/dnd_menu.rs
+git commit -m "$(cat <<'EOF'
+Cancel stale timed-DND timers via expiry token comparison (#31)
+
+build_timed_dnd_button scheduled a glib::timeout_add_local_once for
+each duration click without cancelling the previous one. Re-clicking
+a different duration (e.g. 1h then 2h before the first fires) left
+both armed; the 1h fired first, saw dnd_expires.is_some() (still
+true — the 2h had replaced it), and cleared DND, breaking the user's
+2h reservation early.
+
+Fix by capturing the scheduled expiry as a SystemTime token at
+schedule time. When the timer fires, it compares the current stored
+dnd_expires against its captured value and only acts if they still
+match. Newer schedules replace the stored expiry, so older timers
+no-op silently when they fire.
+
+Cleaner than tracking glib::SourceId (no removal lifetime concerns).
+GTK-bound code; smoke-tested by clicking 1h then 2h in quick
+succession and verifying DND remains on past the 1h mark.
+
+Closes #31.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: #30 — Sync `state.max_history` with `config.max_history`
+
+**Files:**
+- Modify: `src/state.rs` — remove `max_history` field, add `config: Rc<RefCell<NotificationConfig>>` field, update constructor + `trim_history`, update existing tests.
+- Modify: `src/main.rs` — pass `config` (already in scope) to `NotificationState::new`; remove the `let max = s.max_history; s.history.truncate(max);` block in the persisted-history loading branch (it'll come from config now).
+- (Maybe) Modify: any other caller of `NotificationState::new` — check via `grep -rn 'NotificationState::new' src/`.
+
+**Approach:** Add a `config: Rc<RefCell<NotificationConfig>>` field to `NotificationState`. Matches the existing precedent for `dbus_connection: Option<gio::DBusConnection>` on the same struct (state already holds a glib type for callback usage). `trim_history()` reads `self.config.borrow().max_history` instead of `self.max_history`. The `--update --max-history N` path then naturally takes effect on the next `add()` call.
+
+- [ ] **Step 1: Locate all callers of `NotificationState::new`**
+
+```bash
+grep -rn 'NotificationState::new' src/
+```
+
+Expected: 1 production caller in `src/main.rs::activate_notifications`, plus several test sites in `src/state.rs` itself.
+
+- [ ] **Step 2: Update `NotificationState` struct and `new()` signature**
+
+In `src/state.rs`:
+
+```rust
+use crate::config::NotificationConfig;
+use crate::notification::{Notification, Urgency};
+use gtk4::gio;
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::rc::Rc;
+```
+
+(Add the `NotificationConfig` import + `RefCell`/`Rc` imports if not already present.)
+
+Change the struct (remove `max_history` field, add `config` field):
+
+```rust
+pub struct NotificationState {
+    /// All notifications, newest first.
+    pub history: Vec<Notification>,
+    /// Next ID to assign (starts at 1).
+    next_id: u32,
+    /// Do Not Disturb mode.
+    pub dnd: bool,
+    /// When timed DND expires (None = permanent or off).
+    pub dnd_expires: Option<std::time::SystemTime>,
+    /// App directories for icon resolution.
+    pub app_dirs: Vec<PathBuf>,
+    /// IDs of notifications currently showing as popups.
+    pub active_popups: HashSet<u32>,
+    /// Shared daemon configuration. trim_history() reads max_history
+    /// from here so live `--update --max-history` changes take effect
+    /// without a daemon restart (see #30).
+    pub config: Rc<RefCell<NotificationConfig>>,
+    /// D-Bus connection for emitting ActionInvoked signals.
+    pub dbus_connection: Option<gio::DBusConnection>,
+}
+```
+
+Change the constructor:
+
+```rust
+impl NotificationState {
+    pub fn new(app_dirs: Vec<PathBuf>, config: Rc<RefCell<NotificationConfig>>) -> Self {
+        Self {
+            history: Vec::new(),
+            next_id: 1,
+            dnd: false,
+            dnd_expires: None,
+            app_dirs,
+            active_popups: HashSet::new(),
+            config,
+            dbus_connection: None,
+        }
+    }
+```
+
+Change `trim_history`:
+
+```rust
+    fn trim_history(&mut self) {
+        let max_history = self.config.borrow().max_history;
+        if self.history.len() > max_history {
+            self.history.truncate(max_history);
+        }
+    }
+```
+
+- [ ] **Step 3: Update tests in `src/state.rs`**
+
+Tests that construct `NotificationState::new(vec![], 100)` (the second arg is the old `max_history: usize`) need to construct a config too. Add a test helper at the top of the `#[cfg(test)] mod tests` block:
+
+```rust
+    fn test_config_with_max_history(max_history: usize) -> Rc<RefCell<NotificationConfig>> {
+        // Build a default NotificationConfig via clap, then mutate
+        // max_history. Avoids re-deriving the entire default-set inline.
+        use clap::Parser;
+        let mut config = NotificationConfig::parse_from(["test"]);
+        config.max_history = max_history;
+        Rc::new(RefCell::new(config))
+    }
+```
+
+Then update each `NotificationState::new(vec![], <num>)` call to `NotificationState::new(vec![], test_config_with_max_history(<num>))`.
+
+`grep -n 'NotificationState::new' src/state.rs` will list all sites; expect ~10 of them in the existing test suite. Add a new test for the bug fix:
+
+```rust
+    #[test]
+    fn add_respects_live_config_max_history_change() {
+        // Bug fix #30: trim_history must read max_history from the live
+        // config, not a state-side copy.
+        let config = test_config_with_max_history(5);
+        let mut state = NotificationState::new(vec![], Rc::clone(&config));
+        for i in 0..5 {
+            state.add(test_notif("app", &format!("notif {i}")));
+        }
+        assert_eq!(state.history.len(), 5);
+
+        // Simulate `--update --max-history 2` lowering the cap.
+        config.borrow_mut().max_history = 2;
+        state.add(test_notif("app", "trigger"));
+
+        assert_eq!(
+            state.history.len(),
+            2,
+            "trim_history should have read the new max from config; \
+             stuck at 5 means the bug isn't fixed"
+        );
+    }
+```
+
+- [ ] **Step 4: Update `main.rs` callsite**
+
+In `src/main.rs::activate_notifications`, find the existing block:
+
+```rust
+    let app_dirs = get_app_dirs();
+    let state = Rc::new(RefCell::new(NotificationState::new(
+        app_dirs,
+        config.borrow().max_history,
+    )));
+    state.borrow_mut().dnd = config.borrow().dnd;
+```
+
+Change to (drop the `max_history` arg, pass the config Rc):
+
+```rust
+    let app_dirs = get_app_dirs();
+    let state = Rc::new(RefCell::new(NotificationState::new(
+        app_dirs,
+        Rc::clone(config),
+    )));
+    state.borrow_mut().dnd = config.borrow().dnd;
+```
+
+Find the persisted-history loading block:
+
+```rust
+    if config.borrow().persist {
+        let loaded = persistence::load_history(&history_path);
+        if !loaded.is_empty() {
+            log::info!("Loaded {} notifications from history", loaded.len());
+            let mut s = state.borrow_mut();
+            for notif in loaded {
+                s.history.push(notif);
+            }
+            s.history.sort_by_key(|n| std::cmp::Reverse(n.timestamp));
+            let max = s.max_history;
+            s.history.truncate(max);
+        }
+    }
+```
+
+The `let max = s.max_history;` reference no longer compiles. Replace with the config read:
+
+```rust
+    if config.borrow().persist {
+        let loaded = persistence::load_history(&history_path);
+        if !loaded.is_empty() {
+            log::info!("Loaded {} notifications from history", loaded.len());
+            let mut s = state.borrow_mut();
+            for notif in loaded {
+                s.history.push(notif);
+            }
+            s.history.sort_by_key(|n| std::cmp::Reverse(n.timestamp));
+            let max = s.config.borrow().max_history;
+            s.history.truncate(max);
+        }
+    }
+```
+
+(Note: `s.config.borrow().max_history` borrows the inner config through state's Rc — this works because s is `&mut`, so we have exclusive access to state, and the inner borrow is short-lived.)
+
+- [ ] **Step 5: Build, fix any callers I missed, run tests**
+
+```bash
+cargo build 2>&1 | tail -20
+```
+
+Expected: maybe a few errors at other callers of `NotificationState::new` (popup.rs / panel.rs / dnd_menu.rs likely don't construct it themselves, they receive Rc<RefCell<NotificationState>>, but verify). Fix each by passing the config Rc that's already in scope.
+
+```bash
+cargo test
+```
+
+Expected: all 67 tests pass + 1 new `add_respects_live_config_max_history_change` = 68 total.
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/state.rs src/main.rs
+git commit -m "$(cat <<'EOF'
+Sync state.max_history with live config (#30)
+
+The daemon stored max_history twice: on NotificationConfig (read by
+clap, mutable via SetMaxHistory) and on NotificationState (read by
+trim_history() after every add()). At startup state.max_history was
+seeded from config.max_history, but handle_set_max_history only wrote
+the config copy. Result: a user who ran `nwg-notifications --update
+--max-history 50` against a daemon started with the default 200
+would keep retaining 200 entries until the daemon restarted.
+
+Fix per option (a) from the polish-pass review (#29 child #30):
+remove the duplicated state-side field and have trim_history read
+from a Rc<RefCell<NotificationConfig>> threaded through state
+construction. Matches the existing precedent for dbus_connection on
+the same struct.
+
+NotificationState::new signature changed: drops the max_history:
+usize parameter, takes config: Rc<RefCell<NotificationConfig>>
+instead. main.rs callsite updated; persisted-history-loading branch
+reads `s.config.borrow().max_history` instead of `s.max_history`.
+Test helper test_config_with_max_history added in state.rs's mod
+tests for ergonomics; existing tests that constructed state with a
+literal max_history now go through the helper.
+
+1 new test (add_respects_live_config_max_history_change) directly
+exercises the bug-fix path: lower config.max_history below
+history.len(), trigger add(), assert trim. Test count: 67 -> 68.
+
+Closes #30.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md` — one combined Fixed entry under a new `[0.3.5] — Unreleased` section.
+
+- [ ] **Step 1: Add the new section**
+
+Open `CHANGELOG.md`. Find the existing `## [0.3.4] — 2026-05-03` heading and add a new `## [0.3.5] — Unreleased` section above it:
+
+```markdown
+## [0.3.5] — Unreleased
+
+### Fixed
+
+- Four post-v0.3.4 correctness bugs surfaced by the comprehensive
+  code-quality review (epic #29):
+  - `--update --max-history N` now actually changes the trim cap
+    instead of waiting for daemon restart. `trim_history()` reads
+    `max_history` from the live config rather than a state-side copy
+    seeded once at startup. (#30)
+  - Re-clicking a different timed-DND duration before the first
+    timer fires no longer leaves the older one armed and clearing
+    DND early. Each scheduled timer now captures its expiry as a
+    token and no-ops silently if the live expiry has been replaced
+    by a newer schedule. (#31)
+  - `org.freedesktop.Notifications.GetServerInformation` now returns
+    the real vendor (`nwg-notifications`) and version (from
+    `CARGO_PKG_VERSION`). Previously reported vendor
+    `nwg-dock-hyprland` and version `0.1.0` — both pre-split
+    monorepo leftovers visible to any client app or notification
+    debugger. (#32)
+  - Waybar refresh signal is now computed from `libc::SIGRTMIN()` at
+    runtime instead of hardcoded to 45 (which was wrong on musl,
+    where `SIGRTMIN+11 = 46`). musl users were silently sending the
+    wrong signal to waybar. (#33)
+```
+
+(Place above `## [0.3.4] — 2026-05-03`; preserve everything below.)
+
+- [ ] **Step 2: Build, test, clippy sanity**
+
+```bash
+cargo build && cargo test && cargo clippy --all-targets -- -D warnings
+```
+
+Expected: clean (CHANGELOG isn't compiled, but confirms nothing else slipped during the prior tasks).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: changelog for bundled bug fixes (#30 #31 #32 #33)
+
+Add [0.3.5] — Unreleased section with one Fixed bullet per bug,
+each cross-linked to its closing issue.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: User smoke-test gate (HARD STOP)
+
+The 4 fixes touch different surfaces; each gets its own check.
+
+- [ ] **Step 1: Install to the user's `~/.cargo/bin` and restart the daemon**
+
+```bash
+make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+(This is the dev/test recipe — does build + install + restart in one command, preserving the daemon's args.)
+
+Verify the daemon came back up:
+
+```bash
+pidof nwg-notifications && echo "(daemon up with new binary)"
+```
+
+- [ ] **Step 2: Hand off to the user — STOP HERE**
+
+Tell the user (verbatim or close):
+> Installed and restarted via `make upgrade`. Smoke-test paths for each bug:
+>
+> **#32 — GetServerInformation:**
+> ```bash
+> dbus-send --session --print-reply \
+>   --dest=org.freedesktop.Notifications \
+>   /org/freedesktop/Notifications \
+>   org.freedesktop.Notifications.GetServerInformation
+> ```
+> Expect the returned tuple to read `name="nwg-notifications", vendor="nwg-notifications", version="0.3.4", spec="1.2"` (version may differ if Cargo.toml has been bumped).
+>
+> **#33 — waybar refresh signal:**
+> Send a notification and verify the waybar bell badge updates immediately (it currently does on glibc; the fix preserves this behavior on glibc and additionally makes it work on musl). On glibc, the visible behavior is unchanged.
+> ```bash
+> notify-send "test" "should bump waybar count"
+> ```
+>
+> **#31 — timed-DND cancel:**
+> 1. Right-click the waybar bell to open the DND menu.
+> 2. Click "1 hour".
+> 3. Re-open the menu, click "2 hours" (or "until tomorrow").
+> 4. Wait ~1 hour (or temporarily edit the durations to short test values like 30s and 60s, rebuild, retry — easier to verify in-session). After the first timer would have fired, DND should still be on.
+>
+> **#30 — max-history sync:**
+> ```bash
+> # Start with default max-history (200) — should already be running.
+> # Send 5 notifications:
+> for i in 1 2 3 4 5; do notify-send "fill $i" "msg"; sleep 0.2; done
+> # Lower the cap:
+> nwg-notifications --update --max-history 2
+> # Trigger a trim by sending one more:
+> notify-send "trigger" "msg"
+> # Open the panel via waybar bell — expect exactly 2 entries
+> # (the new "trigger" + 1 of the most recent fills). Pre-fix, this
+> # would still show 6 entries because trim_history was reading the
+> # stale state-side copy.
+> ```
+>
+> Reply when satisfied or with anything that needs fixing.
+
+**Do not proceed to Task 7 until the user explicitly approves.** If they report issues, return to the broken task.
+
+---
+
+## Task 7: Full cargo gambit (CI parity)
+
+- [ ] **Step 1: `make lint`**
+
+```bash
+make lint
+```
+
+If `cargo fmt --check` reformats anything, run `cargo fmt --all`, commit as `style: cargo fmt`, re-run `make lint`. Stop on new deny/audit findings.
+
+- [ ] **Step 2: Confirm clean working tree**
+
+```bash
+git status
+```
+
+Expected: clean.
+
+---
+
+## Task 8: Open the PR
+
+Gated on Task 6 (user smoke-test approval) AND Task 7 (clean `make lint`).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/bundled-bugs-30-31-32-33
+```
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+gh pr create --title "Bundle four post-v0.3.4 correctness bugs (#30 #31 #32 #33)" --body "$(cat <<'EOF'
+## Summary
+
+Bundles the four "ship first" correctness bug fixes from the [post-v0.3.4 polish-pass epic (#29)](https://github.com/jasonherald/nwg-notifications/issues/29) into one PR. Bundled because we're outrunning CodeRabbit's review capacity and these four are the most user-visible bugs. Each fix is its own commit; each closes its parent issue.
+
+| Bug | What was wrong | What changed |
+|---|---|---|
+| #30 | `--update --max-history N` didn't actually change trim behavior until daemon restart | `state.max_history` field removed; `trim_history()` reads from live `Rc<RefCell<NotificationConfig>>` |
+| #31 | Re-clicking a different timed-DND duration left both timers armed; older one cleared DND early | Each timer captures its expiry as a token and no-ops if the live expiry was replaced |
+| #32 | `GetServerInformation` reported vendor `nwg-dock-hyprland` and version `0.1.0` (monorepo leftovers) | Returns real vendor + `env!("CARGO_PKG_VERSION")` |
+| #33 | `WAYBAR_REFRESH_SIGNAL: i32 = 45` was wrong on musl (SIGRTMIN+11 = 46 there) | Computed from `libc::SIGRTMIN()` at runtime |
+
+Closes #30, #31, #32, #33. Children of epic #29.
+
+## Test plan
+
+- [x] `make lint` — fmt + clippy + test + deny + audit, all green locally.
+- [x] 3 new unit tests (test count: 65 → 68):
+  - `server_info_tuple_uses_cargo_pkg_version` — asserts the helper returns the real version string.
+  - `waybar_refresh_signal_is_sigrtmin_plus_11` — asserts the helper returns `libc::SIGRTMIN() + 11` and stays below `SIGRTMAX`.
+  - `add_respects_live_config_max_history_change` — directly exercises the bug-fix path for #30.
+- [x] Manual smoke test against the live compositor (installed via `make upgrade PREFIX=\$HOME/.local BINDIR=\$HOME/.cargo/bin`):
+  - [x] `dbus-send GetServerInformation` returns real name/vendor/version.
+  - [x] `notify-send` still triggers the waybar refresh on glibc (we don't have musl to verify, but the helper is straight-line).
+  - [x] Re-click 1h then 2h (or shorter test durations) — DND remains on past the first timer's mark.
+  - [x] `--update --max-history 2` after filling history to 5 entries — next `notify-send` trims down to exactly 2.
+
+## Notes
+
+- For #33 the original review item suggested adding a `pub fn sig_waybar_refresh()` to `nwg-common::signals`. nwg-common's `sigrtmin()` is currently private and adding a public helper is a cross-repo PR + crates.io publish — out of scope for a "ship now" bundle. The `nwg-common-candidate` label on #33 stays so the eventual promotion is tracked.
+- For #31 the GTK timer logic isn't unit-testable from inside an isolated `#[test]`. Smoke test covers the user-visible behavior; D-Bus integration tests (#16) would eventually let us automate this.
+- Each bug got its own commit with the standard "Closes #NN" trailer so GitHub correctly auto-closes each child issue on merge.
+
+The implementation plan (committed as `docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md`) is on the branch for reviewer context.
+EOF
+)"
+```
+
+Expected: returns the PR URL.
+
+- [ ] **Step 3: Hand off to CodeRabbit**
+
+CodeRabbit reviews within minutes. **Default to fixing every finding in-PR.** Defer only when the fix needs new infrastructure or has wide blast radius — and when you do defer, open a tracking issue *first*. Reply protocol: inline replies for in-diff comments, single PR-level comment for outside-diff items, tag `@coderabbitai` every time so it learns from the responses.
+
+---
+
+## Acceptance checklist (cross-reference to issues)
+
+- [ ] **#30:** `state.max_history` field removed; `trim_history()` reads from `config.max_history`; `--update --max-history` takes effect on next `add()` call without daemon restart. — Task 4
+- [ ] **#31:** Re-clicking a different timed-DND duration before the previous timer fires leaves only the most recent expiry effective. — Task 3
+- [ ] **#32:** `GetServerInformation` returns name `nwg-notifications`, vendor `nwg-notifications`, version from `Cargo.toml`. — Task 1
+- [ ] **#33:** No hardcoded `45` (or `34`/`35`) in `waybar.rs`; signal is computed from `libc::SIGRTMIN()`. — Task 2
+- [ ] CHANGELOG entry under new `[0.3.5] — Unreleased` Fixed section. — Task 5
+- [ ] Smoke-test paths verified for all four. — Task 6

--- a/docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md
+++ b/docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md
@@ -17,7 +17,7 @@
 | Task | Files modified | Test approach |
 |------|---------------|---------------|
 | #32 GetServerInformation | `src/dbus.rs` (extract pure helper + 1 test) | Unit test on the helper |
-| #33 WAYBAR_REFRESH_SIGNAL | `src/waybar.rs` | Smoke test only (signal delivery) |
+| #33 WAYBAR_REFRESH_SIGNAL | `src/waybar.rs` | Unit test asserts helper returns `SIGRTMIN + offset`; smoke test confirms waybar still refreshes |
 | #31 timed-DND cancel | `src/ui/dnd_menu.rs` | Smoke test only (GTK timer) |
 | #30 max_history sync | `src/state.rs`, `src/main.rs`, `src/ui/dnd_menu.rs` (any callers of `NotificationState::new`) | Existing `trim_history_caps_at_max` test updated; new test for `--update --max-history` semantics |
 
@@ -696,16 +696,19 @@ Tell the user (verbatim or close):
 > Installed and restarted via `make upgrade`. Smoke-test paths for each bug:
 >
 > **#32 — GetServerInformation:**
+>
 > ```bash
 > dbus-send --session --print-reply \
 >   --dest=org.freedesktop.Notifications \
 >   /org/freedesktop/Notifications \
 >   org.freedesktop.Notifications.GetServerInformation
 > ```
+>
 > Expect the returned tuple to read `name="nwg-notifications", vendor="nwg-notifications", version="0.3.4", spec="1.2"` (version may differ if Cargo.toml has been bumped).
 >
 > **#33 — waybar refresh signal:**
 > Send a notification and verify the waybar bell badge updates immediately (it currently does on glibc; the fix preserves this behavior on glibc and additionally makes it work on musl). On glibc, the visible behavior is unchanged.
+>
 > ```bash
 > notify-send "test" "should bump waybar count"
 > ```
@@ -717,6 +720,7 @@ Tell the user (verbatim or close):
 > 4. Wait ~1 hour (or temporarily edit the durations to short test values like 30s and 60s, rebuild, retry — easier to verify in-session). After the first timer would have fired, DND should still be on.
 >
 > **#30 — max-history sync:**
+>
 > ```bash
 > # Start with default max-history (200) — should already be running.
 > # Send 5 notifications:

--- a/docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md
+++ b/docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md
@@ -169,6 +169,11 @@ const WAYBAR_REFRESH_SIGNAL: i32 = 45;
 Add this helper in its place (near the top, just after the imports):
 
 ```rust
+/// Offset above `SIGRTMIN` that waybar's notification module listens on.
+/// Kept as a single named constant so the implementation and its test
+/// can't drift apart.
+const WAYBAR_REFRESH_SIGNAL_OFFSET: i32 = 11;
+
 /// Returns the runtime signal number for the waybar refresh signal
 /// (SIGRTMIN+11). Computed from `libc::SIGRTMIN()` rather than hardcoded
 /// because the value differs across libc implementations: glibc reserves
@@ -178,7 +183,7 @@ Add this helper in its place (near the top, just after the imports):
 /// internally; we duplicate the call here rather than depend on a
 /// (currently private) helper there. See #33.
 fn waybar_refresh_signal() -> i32 {
-    libc::SIGRTMIN() + 11
+    libc::SIGRTMIN() + WAYBAR_REFRESH_SIGNAL_OFFSET
 }
 ```
 
@@ -206,10 +211,14 @@ In `src/waybar.rs`'s `#[cfg(test)] mod tests` block, append:
 
 ```rust
     #[test]
-    fn waybar_refresh_signal_is_sigrtmin_plus_11() {
+    fn waybar_refresh_signal_is_sigrtmin_plus_offset() {
         let s = waybar_refresh_signal();
         let base = libc::SIGRTMIN();
-        assert_eq!(s, base + 11, "expected SIGRTMIN({base}) + 11, got {s}");
+        assert_eq!(
+            s,
+            base + WAYBAR_REFRESH_SIGNAL_OFFSET,
+            "expected SIGRTMIN({base}) + {WAYBAR_REFRESH_SIGNAL_OFFSET}, got {s}"
+        );
         // Cross-check that the value is in the RT-signal range. SIGRTMIN
         // is at minimum 33 on Linux; SIGRTMAX is at most 64. SIGRTMIN+11
         // must fit comfortably below SIGRTMAX even on the more
@@ -793,7 +802,7 @@ Closes #30, #31, #32, #33. Children of epic #29.
 - [x] `make lint` — fmt + clippy + test + deny + audit, all green locally.
 - [x] 3 new unit tests (test count: 65 → 68):
   - `server_info_tuple_uses_cargo_pkg_version` — asserts the helper returns the real version string.
-  - `waybar_refresh_signal_is_sigrtmin_plus_11` — asserts the helper returns `libc::SIGRTMIN() + 11` and stays below `SIGRTMAX`.
+  - `waybar_refresh_signal_is_sigrtmin_plus_offset` — asserts the helper returns `libc::SIGRTMIN() + WAYBAR_REFRESH_SIGNAL_OFFSET` and stays below `SIGRTMAX`.
   - `add_respects_live_config_max_history_change` — directly exercises the bug-fix path for #30.
 - [x] Manual smoke test against the live compositor (installed via `make upgrade PREFIX=\$HOME/.local BINDIR=\$HOME/.cargo/bin`):
   - [x] `dbus-send GetServerInformation` returns real name/vendor/version.

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -520,7 +520,12 @@ fn handle_capabilities(invocation: gio::DBusMethodInvocation) {
 /// with releases automatically; spec_version tracks the freedesktop
 /// notification specification level we implement.
 fn server_info_tuple() -> (&'static str, &'static str, &'static str, &'static str) {
-    ("nwg-notifications", "nwg-notifications", env!("CARGO_PKG_VERSION"), "1.2")
+    (
+        "nwg-notifications",
+        "nwg-notifications",
+        env!("CARGO_PKG_VERSION"),
+        "1.2",
+    )
 }
 
 fn handle_server_info(invocation: gio::DBusMethodInvocation) {

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -513,8 +513,18 @@ fn handle_capabilities(invocation: gio::DBusMethodInvocation) {
     invocation.return_value(Some(&variant));
 }
 
+/// Returns the (name, vendor, version, spec_version) tuple reported by the
+/// `org.freedesktop.Notifications.GetServerInformation` D-Bus method.
+/// Vendor is the daemon's own name (single-vendor project convention);
+/// version comes from `Cargo.toml` at compile time so it stays in sync
+/// with releases automatically; spec_version tracks the freedesktop
+/// notification specification level we implement.
+fn server_info_tuple() -> (&'static str, &'static str, &'static str, &'static str) {
+    ("nwg-notifications", "nwg-notifications", env!("CARGO_PKG_VERSION"), "1.2")
+}
+
 fn handle_server_info(invocation: gio::DBusMethodInvocation) {
-    let info = ("nwg-notifications", "nwg-dock-hyprland", "0.1.0", "1.2");
+    let info = server_info_tuple();
     let variant = glib::Variant::from(info);
     invocation.return_value(Some(&variant));
 }
@@ -712,5 +722,14 @@ mod tests {
     fn is_unknown_method_error_rejects_other_dbus_errors() {
         let err = glib::Error::new(gio::DBusError::NoMemory, "out of memory");
         assert!(!is_unknown_method_error(&err));
+    }
+
+    #[test]
+    fn server_info_tuple_uses_cargo_pkg_version() {
+        let (name, vendor, version, spec) = server_info_tuple();
+        assert_eq!(name, "nwg-notifications");
+        assert_eq!(vendor, "nwg-notifications");
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(spec, "1.2");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn activate_notifications(
     let app_dirs = get_app_dirs();
     let state = Rc::new(RefCell::new(NotificationState::new(
         app_dirs,
-        config.borrow().max_history,
+        Rc::clone(config),
     )));
     state.borrow_mut().dnd = config.borrow().dnd;
 
@@ -169,7 +169,7 @@ fn activate_notifications(
                 s.history.push(notif);
             }
             s.history.sort_by_key(|n| std::cmp::Reverse(n.timestamp));
-            let max = s.max_history;
+            let max = s.config.borrow().max_history;
             s.history.truncate(max);
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,10 @@
+use crate::config::NotificationConfig;
 use crate::notification::{Notification, Urgency};
 use gtk4::gio;
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 /// A group of notifications from the same application.
 pub struct AppGroup {
@@ -24,14 +27,16 @@ pub struct NotificationState {
     pub app_dirs: Vec<PathBuf>,
     /// IDs of notifications currently showing as popups.
     pub active_popups: HashSet<u32>,
-    /// Maximum history entries to retain.
-    pub max_history: usize,
+    /// Shared daemon configuration. trim_history() reads max_history
+    /// from here so live `--update --max-history` changes take effect
+    /// without a daemon restart (see #30).
+    pub config: Rc<RefCell<NotificationConfig>>,
     /// D-Bus connection for emitting ActionInvoked signals.
     pub dbus_connection: Option<gio::DBusConnection>,
 }
 
 impl NotificationState {
-    pub fn new(app_dirs: Vec<PathBuf>, max_history: usize) -> Self {
+    pub fn new(app_dirs: Vec<PathBuf>, config: Rc<RefCell<NotificationConfig>>) -> Self {
         Self {
             history: Vec::new(),
             next_id: 1,
@@ -39,7 +44,7 @@ impl NotificationState {
             dnd_expires: None,
             app_dirs,
             active_popups: HashSet::new(),
-            max_history,
+            config,
             dbus_connection: None,
         }
     }
@@ -130,8 +135,9 @@ impl NotificationState {
     }
 
     fn trim_history(&mut self) {
-        if self.history.len() > self.max_history {
-            self.history.truncate(self.max_history);
+        let max_history = self.config.borrow().max_history;
+        if self.history.len() > max_history {
+            self.history.truncate(max_history);
         }
     }
 }
@@ -140,6 +146,15 @@ impl NotificationState {
 mod tests {
     use super::*;
     use std::time::SystemTime;
+
+    fn test_config_with_max_history(max_history: usize) -> Rc<RefCell<NotificationConfig>> {
+        // Build a default NotificationConfig via clap, then mutate
+        // max_history. Avoids re-deriving the entire default-set inline.
+        use clap::Parser;
+        let mut config = NotificationConfig::parse_from(["test"]);
+        config.max_history = max_history;
+        Rc::new(RefCell::new(config))
+    }
 
     fn test_notif(app: &str, summary: &str) -> Notification {
         Notification {
@@ -159,7 +174,7 @@ mod tests {
 
     #[test]
     fn add_assigns_sequential_ids() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         let id1 = state.add(test_notif("app1", "first"));
         let id2 = state.add(test_notif("app2", "second"));
         assert_eq!(id1, 1);
@@ -168,7 +183,7 @@ mod tests {
 
     #[test]
     fn replace_reuses_id() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         let id = state.add(test_notif("app", "original"));
         let replaced = state.replace(id, test_notif("app", "updated"));
         assert_eq!(replaced, id);
@@ -178,7 +193,7 @@ mod tests {
 
     #[test]
     fn dismiss_app_removes_only_matching() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         state.add(test_notif("firefox", "tab1"));
         state.add(test_notif("discord", "msg1"));
         state.add(test_notif("firefox", "tab2"));
@@ -189,7 +204,7 @@ mod tests {
 
     #[test]
     fn unread_count() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         let id1 = state.add(test_notif("app", "one"));
         state.add(test_notif("app", "two"));
         assert_eq!(state.unread_count(), 2);
@@ -199,7 +214,7 @@ mod tests {
 
     #[test]
     fn grouped_by_app_groups_correctly() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         state.add(test_notif("firefox", "tab1"));
         state.add(test_notif("discord", "msg"));
         state.add(test_notif("firefox", "tab2"));
@@ -209,7 +224,7 @@ mod tests {
 
     #[test]
     fn dnd_suppresses_normal_popups() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         state.dnd = true;
         assert!(!state.should_show_popup(Urgency::Normal));
         assert!(!state.should_show_popup(Urgency::Low));
@@ -218,7 +233,7 @@ mod tests {
 
     #[test]
     fn trim_history_caps_at_max() {
-        let mut state = NotificationState::new(vec![], 3);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(3));
         state.add(test_notif("app", "1"));
         state.add(test_notif("app", "2"));
         state.add(test_notif("app", "3"));
@@ -238,7 +253,7 @@ mod tests {
 
         // Also verify via state: use replace to set a known ID, then
         // confirm next_id never produces 0.
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         // Manually push next_id close to wrapping by using replace with
         // high IDs. The simplest approach: add notifications and confirm
         // the returned IDs are sequential starting from 1.
@@ -253,13 +268,13 @@ mod tests {
 
     #[test]
     fn remove_nonexistent_returns_none() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         assert!(state.remove(999).is_none());
     }
 
     #[test]
     fn dismiss_all_clears_everything() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         let id1 = state.add(test_notif("app1", "one"));
         let id2 = state.add(test_notif("app2", "two"));
         state.add(test_notif("app3", "three"));
@@ -274,7 +289,7 @@ mod tests {
 
     #[test]
     fn mark_read_nonexistent_no_panic() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         state.add(test_notif("app", "exists"));
         // Marking a non-existent ID should not panic.
         state.mark_read(999);
@@ -284,7 +299,7 @@ mod tests {
 
     #[test]
     fn active_popups_tracking() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         state.active_popups.insert(42);
         assert!(state.active_popups.contains(&42));
         state.active_popups.remove(&42);
@@ -293,7 +308,7 @@ mod tests {
 
     #[test]
     fn empty_state_operations() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         assert_eq!(state.unread_count(), 0);
         assert!(state.grouped_by_app().is_empty());
         // dismiss_all on empty state should not panic.
@@ -303,7 +318,7 @@ mod tests {
 
     #[test]
     fn replace_nonexistent_creates_new() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         // Replace with an ID that doesn't exist falls through to add().
         let id = state.replace(999, test_notif("app", "new"));
         // Should have created a new entry with a fresh ID (1, since state is new).
@@ -314,7 +329,7 @@ mod tests {
 
     #[test]
     fn history_ordering_newest_first() {
-        let mut state = NotificationState::new(vec![], 100);
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
         state.add(test_notif("app", "first"));
         state.add(test_notif("app", "second"));
         state.add(test_notif("app", "third"));
@@ -322,5 +337,28 @@ mod tests {
         assert_eq!(state.history[0].summary, "third");
         assert_eq!(state.history[1].summary, "second");
         assert_eq!(state.history[2].summary, "first");
+    }
+
+    #[test]
+    fn add_respects_live_config_max_history_change() {
+        // Bug fix #30: trim_history must read max_history from the live
+        // config, not a state-side copy.
+        let config = test_config_with_max_history(5);
+        let mut state = NotificationState::new(vec![], Rc::clone(&config));
+        for i in 0..5 {
+            state.add(test_notif("app", &format!("notif {i}")));
+        }
+        assert_eq!(state.history.len(), 5);
+
+        // Simulate `--update --max-history 2` lowering the cap.
+        config.borrow_mut().max_history = 2;
+        state.add(test_notif("app", "trigger"));
+
+        assert_eq!(
+            state.history.len(),
+            2,
+            "trim_history should have read the new max from config; \
+             stuck at 5 means the bug isn't fixed"
+        );
     }
 }

--- a/src/ui/dnd_menu.rs
+++ b/src/ui/dnd_menu.rs
@@ -215,17 +215,26 @@ fn build_timed_dnd_button(
         state_btn.borrow_mut().dnd_expires = Some(expiry);
         log::info!("DND enabled for {} minutes", minutes);
 
+        // Capture the expiry we just stored. If the user clicks a
+        // different duration before this timer fires, the stored
+        // expiry will have been replaced; this timer's `expiry` token
+        // won't match and the firing will no-op. Cleaner than
+        // tracking a glib::SourceId and removing the previous source
+        // (no removal lifetime concerns).
+        let captured_expiry = expiry;
         let state_timer = Rc::clone(&state_btn);
         let on_change_timer = Rc::clone(&on_change);
         gtk4::glib::timeout_add_local_once(
             std::time::Duration::from_secs(minutes * 60),
             move || {
-                if state_timer.borrow().dnd_expires.is_some() {
+                let current = state_timer.borrow().dnd_expires;
+                if current == Some(captured_expiry) {
                     state_timer.borrow_mut().dnd = false;
                     state_timer.borrow_mut().dnd_expires = None;
                     log::info!("Timed DND expired");
                     on_change_timer();
                 }
+                // else: a newer schedule replaced this one; no-op silently.
             },
         );
 

--- a/src/waybar.rs
+++ b/src/waybar.rs
@@ -1,6 +1,11 @@
 use serde::Serialize;
 use std::path::PathBuf;
 
+/// Offset above `SIGRTMIN` that waybar's notification module listens on.
+/// Kept as a single named constant so the implementation and its test
+/// can't drift apart.
+const WAYBAR_REFRESH_SIGNAL_OFFSET: i32 = 11;
+
 /// Returns the runtime signal number for the waybar refresh signal
 /// (SIGRTMIN+11). Computed from `libc::SIGRTMIN()` rather than hardcoded
 /// because the value differs across libc implementations: glibc reserves
@@ -10,7 +15,7 @@ use std::path::PathBuf;
 /// internally; we duplicate the call here rather than depend on a
 /// (currently private) helper there. See #33.
 fn waybar_refresh_signal() -> i32 {
-    libc::SIGRTMIN() + 11
+    libc::SIGRTMIN() + WAYBAR_REFRESH_SIGNAL_OFFSET
 }
 
 #[derive(Serialize)]
@@ -109,10 +114,14 @@ mod tests {
     }
 
     #[test]
-    fn waybar_refresh_signal_is_sigrtmin_plus_11() {
+    fn waybar_refresh_signal_is_sigrtmin_plus_offset() {
         let s = waybar_refresh_signal();
         let base = libc::SIGRTMIN();
-        assert_eq!(s, base + 11, "expected SIGRTMIN({base}) + 11, got {s}");
+        assert_eq!(
+            s,
+            base + WAYBAR_REFRESH_SIGNAL_OFFSET,
+            "expected SIGRTMIN({base}) + {WAYBAR_REFRESH_SIGNAL_OFFSET}, got {s}"
+        );
         // Cross-check that the value is in the RT-signal range. SIGRTMIN
         // is at minimum 33 on Linux; SIGRTMAX is at most 64. SIGRTMIN+11
         // must fit comfortably below SIGRTMAX even on the more

--- a/src/waybar.rs
+++ b/src/waybar.rs
@@ -1,8 +1,17 @@
 use serde::Serialize;
 use std::path::PathBuf;
 
-/// Waybar refresh signal: SIGRTMIN+11 = 34+11 = 45.
-const WAYBAR_REFRESH_SIGNAL: i32 = 45;
+/// Returns the runtime signal number for the waybar refresh signal
+/// (SIGRTMIN+11). Computed from `libc::SIGRTMIN()` rather than hardcoded
+/// because the value differs across libc implementations: glibc reserves
+/// the first two RT signals (so `SIGRTMIN` = 34, hence SIGRTMIN+11 = 45),
+/// while musl reserves three (so `SIGRTMIN` = 35, hence SIGRTMIN+11 = 46).
+/// The nwg-common crate uses the same `libc::SIGRTMIN()` lookup
+/// internally; we duplicate the call here rather than depend on a
+/// (currently private) helper there. See #33.
+fn waybar_refresh_signal() -> i32 {
+    libc::SIGRTMIN() + 11
+}
 
 #[derive(Serialize)]
 struct WaybarStatus {
@@ -67,8 +76,9 @@ pub fn update_status(unread: usize, dnd: bool) {
 
 /// Sends SIGRTMIN+11 to waybar to refresh the notification module.
 fn signal_waybar() {
+    let signal_num = waybar_refresh_signal();
     match std::process::Command::new("pkill")
-        .arg(format!("-{WAYBAR_REFRESH_SIGNAL}"))
+        .arg(format!("-{signal_num}"))
         .arg("waybar")
         .status()
     {
@@ -96,5 +106,17 @@ mod tests {
             json.contains("\"count\":7"),
             "expected count field in JSON, got: {json}"
         );
+    }
+
+    #[test]
+    fn waybar_refresh_signal_is_sigrtmin_plus_11() {
+        let s = waybar_refresh_signal();
+        let base = libc::SIGRTMIN();
+        assert_eq!(s, base + 11, "expected SIGRTMIN({base}) + 11, got {s}");
+        // Cross-check that the value is in the RT-signal range. SIGRTMIN
+        // is at minimum 33 on Linux; SIGRTMAX is at most 64. SIGRTMIN+11
+        // must fit comfortably below SIGRTMAX even on the more
+        // restrictive musl layout.
+        assert!(s < libc::SIGRTMAX(), "signal {s} exceeds SIGRTMAX");
     }
 }


### PR DESCRIPTION
## Summary

Bundles the four "ship first" correctness bug fixes from the [post-v0.3.4 polish-pass epic (#29)](https://github.com/jasonherald/nwg-notifications/issues/29) into one PR. Bundled because we're outrunning CodeRabbit's review capacity and these four are the most user-visible bugs. Each fix is its own commit; each closes its parent issue.

| Bug | What was wrong | What changed |
|---|---|---|
| #30 | \`--update --max-history N\` didn't actually change trim behavior until daemon restart | \`state.max_history\` field removed; \`trim_history()\` reads from live \`Rc<RefCell<NotificationConfig>>\` |
| #31 | Re-clicking a different timed-DND duration left both timers armed; older one cleared DND early | Each timer captures its expiry as a token and no-ops if the live expiry was replaced |
| #32 | \`GetServerInformation\` reported vendor \`nwg-dock-hyprland\` and version \`0.1.0\` (monorepo leftovers) | Returns real vendor + \`env!("CARGO_PKG_VERSION")\` |
| #33 | \`WAYBAR_REFRESH_SIGNAL: i32 = 45\` was wrong on musl (SIGRTMIN+11 = 46 there) | Computed from \`libc::SIGRTMIN()\` at runtime |

Closes #30, #31, #32, #33. Children of epic #29.

## Test plan

- [x] \`make lint\` — fmt + clippy + test + deny + audit, all green locally.
- [x] 3 new unit tests (test count: 65 → 68):
  - \`server_info_tuple_uses_cargo_pkg_version\` — asserts the helper returns the real version string.
  - \`waybar_refresh_signal_is_sigrtmin_plus_11\` — asserts the helper returns \`libc::SIGRTMIN() + 11\` and stays below \`SIGRTMAX\`.
  - \`add_respects_live_config_max_history_change\` — directly exercises the bug-fix path for #30.
- [x] Manual smoke test against the live compositor (installed via \`make upgrade PREFIX=\$HOME/.local BINDIR=\$HOME/.cargo/bin\`):
  - [x] \`dbus-send GetServerInformation\` returns real name/vendor/version.
  - [x] \`notify-send\` still triggers the waybar refresh on glibc.
  - [x] Re-click 1h then a different duration — DND remains on past the first timer's mark.
  - [x] \`--update --max-history 2\` after filling history — next \`notify-send\` trims down to exactly 2.

## Notes

- For #33 the original review item suggested adding a \`pub fn sig_waybar_refresh()\` to \`nwg-common::signals\`. That crate's \`sigrtmin()\` is currently private and adding a public helper is a cross-repo PR + crates.io publish — out of scope for this "ship now" bundle. The \`nwg-common-candidate\` label on #33 stays so the eventual promotion is tracked.
- For #31 the GTK timer logic isn't unit-testable from inside an isolated \`#[test]\`. Smoke test covers the user-visible behavior; D-Bus integration tests (#16) would eventually let us automate this.
- For #30 the constructor signature changed (\`NotificationState::new(app_dirs, config)\` instead of \`NotificationState::new(app_dirs, max_history)\`). 15 existing test sites updated via a \`test_config_with_max_history\` helper to keep the per-site noise down.
- Each bug got its own commit with the standard "Closes #NN" trailer so GitHub correctly auto-closes each child issue on merge.
- Subagent-driven development workflow used throughout — each task got an Opus implementer + spec compliance review + code quality review.

The implementation plan (committed as \`docs/superpowers/plans/2026-05-03-bundled-bug-fixes-30-31-32-33.md\`) is on the branch for reviewer context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server information now reports the correct application/version.
  * `--update --max-history` now applies config changes live without restarting.
  * Do Not Disturb scheduling no longer prematurely clears when a timed DND is re-scheduled.
  * Waybar refresh signaling computed at runtime to avoid platform-specific mismatches.

* **Documentation**
  * CHANGELOG updated and a bundled bug‑fix plan added describing the grouped fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->