### PR TITLE
chore: release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
-## [0.3.5] — Unreleased
+## [0.3.5] — 2026-05-03
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     where `SIGRTMIN+11 = 46`). musl users were silently sending the
     wrong signal to waybar. (#33)
 
+### Changed
+
+- Bumped `nwg-common` dependency from `0.3` to `0.4`. No public-API
+  impact for `nwg-notifications`: the only breaking change in
+  `nwg-common 0.4.0` is the new required `Compositor::focus_workspace`
+  trait method, and we only consume `Rc<dyn Compositor>` rather than
+  implementing the trait ourselves. Pulled in for the workspace-switcher
+  event surface (`WmEvent::WorkspaceChanged`) and the warn-log on
+  `init_or_null` fallback that other consumers in the nwg-* family
+  rely on.
+
 ## [0.3.4] — 2026-05-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-notifications"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "nwg-common"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bddf3aa18bcf84a0871017c6837def43f7f47250e0d6832b46d2bcde34f39c3"
+checksum = "406ced31ecc8842d92eb2c828dc9ad69ba143ebbdbeae702041ec0da02026977"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-notifications"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Shared library (library + binaries all on the 0.3.x line)
-nwg-common = "0.3.1"
+nwg-common = "0.4"
 
 # GTK4 + Wayland layer shell. `gtk4::gio` provides the D-Bus server
 # plumbing (bus_own_name, BusType::Session, DBusConnection); no


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` to `0.3.5` and promotes the `[0.3.5] — Unreleased` CHANGELOG section to `[0.3.5] — 2026-05-03`.
- Releases the four bundled correctness bug fixes shipped in PR #52: #30, #31, #32, #33 (all children of epic #29, the post-v0.3.4 polish pass).
- Bumps `nwg-common` dep from `0.3` → `0.4` to pick up the workspace-switcher event surface and `init_or_null` warn-log. No code changes needed locally — we only consume `Rc<dyn Compositor>`, never impl it.

## Test plan

- [x] `make lint` clean locally (fmt + clippy + test + deny + audit) on both the version-bump commit and the nwg-common bump commit.
- [x] 68 unit tests pass with nwg-common 0.4.
- [x] Manual smoke-tested on the live compositor for all four bug fixes (see PR #52 verification thread).
- [ ] Tag `v0.3.5` and run `cargo publish` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live history trimming now respects runtime update settings.
  * Prevented stale timed Do Not Disturb timers from firing after rescheduling.
  * Corrected server info so product name and version report accurately.
  * Fixed Waybar refresh signal computation to use runtime values.

* **Changed**
  * Updated shared/common dependency to a newer compatible release.

* **Documentation**
  * Changelog entry finalized with release date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->