### PR TITLE
Bundle state refactor: #37 #39

### DIFF
--- a/docs/superpowers/plans/2026-05-03-bundle-state-refactor-37-39.md
+++ b/docs/superpowers/plans/2026-05-03-bundle-state-refactor-37-39.md
@@ -1,0 +1,716 @@
+# Bundle State Refactor (#39, #37) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bundle two internal-state refactors from epic #29 — extract the two filename-construction helpers into a new `src/paths.rs` module (#39), and centralize the five `state.dnd` / `state.dnd_expires` write sites into a single `NotificationState::set_dnd(enabled, expires)` helper (#37). The latter also fixes a latent stale-`dnd_expires` bug in two of the call sites.
+
+**Architecture:** Both refactors are pure "pull repeated logic into one place." #39 creates a new `paths` module that owns both filename conventions; `persistence.rs` and `waybar.rs` import them. #37 adds an `impl` method that becomes the only writer of the `dnd` and `dnd_expires` fields; all five existing write sites route through it (each passing the expiry it wants — signal/header pass `None`, timed-DND passes `Some(expiry)`, the timer-fire passes `None`). One commit per issue, #39 first because it's mechanical with no behavior change.
+
+**Tech Stack:** Rust modules, `Rc<RefCell<NotificationState>>` shared-state pattern, `std::time::SystemTime` for the expiry token.
+
+**Tracks:** Closes #39, #37. Both are children of epic #29.
+
+---
+
+## File Structure
+
+| Task | Files modified | Test approach |
+|------|----------------|---------------|
+| #39 paths module | New `src/paths.rs` (lifts both helpers); `src/main.rs` (declares `mod paths;`); `src/persistence.rs` (drops `history_path`, imports from `paths`); `src/waybar.rs` (drops `status_path`, imports from `paths`); `src/main.rs` (call site `persistence::history_path()` → `paths::history_path()`) | `cargo build --release` clean; `make lint` green; daemon still writes the same files |
+| #37 set_dnd helper | `src/state.rs` (add `set_dnd` method, update existing test write site, add new unit test); `src/listeners.rs` (`ToggleDnd` arm); `src/ui/panel.rs` (panel header DND button); `src/ui/dnd_menu.rs` (3 sites: toggle, timed-DND button, timer-fire) | New unit test asserts the bug fix: enabling timed DND then toggling via signal correctly clears `dnd_expires` |
+
+Each issue gets its own commit. No CHANGELOG entry — internal refactor; the bug fix in #37 is a latent issue that's never been reported (the stale `dnd_expires` is mostly harmless because the timer-fire token check makes it a no-op if the user cycles quickly enough; worst case the timer fires later and re-clears DND that's already off, which is invisible).
+
+---
+
+## Pre-flight
+
+- [ ] **Sync main and create branch**
+
+```bash
+cd /data/source/nwg-notifications
+git checkout main && git pull --ff-only
+git status
+git checkout -b chore/state-refactor-37-39
+```
+
+Expected: clean tree on `main`, then a fresh branch.
+
+- [ ] **Commit the plan file as the first commit on the branch**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-bundle-state-refactor-37-39.md
+git commit -m "docs: implementation plan for state-refactor bundle (#37 #39)"
+```
+
+- [ ] **Baseline full cargo gambit**
+
+```bash
+make lint
+```
+
+Expected: every step exits 0; pre-existing `cargo deny` "unmatched skip" warnings are non-blocking. Test count is 87 going in.
+
+---
+
+## Task 1: #39 — Extract `history_path` and `status_path` into a new `paths` module
+
+`history_path()` in `persistence.rs` and `status_path()` in `waybar.rs` are two near-identical "join a base dir against a fixed filename" helpers. Lift them into a new `src/paths.rs` so the filename conventions live together and the eventual `mac-notifications-*` → `nwg-notifications-*` rename in #34 is a one-file diff.
+
+**Files:**
+- Create: `src/paths.rs`
+- Modify: `src/main.rs` — add `mod paths;` declaration alongside the existing `mod` lines + update the `persistence::history_path()` call site
+- Modify: `src/persistence.rs` — delete the local `history_path()` function (its body moves to `paths`); the file shouldn't import `paths` itself since `load_history` and `save_history` already take a `&Path` parameter
+- Modify: `src/waybar.rs` — delete the local `status_path()` function; the call site in `update_status` switches to `crate::paths::status_path()`
+
+- [ ] **Step 1: Create `src/paths.rs`**
+
+Create the new file at `src/paths.rs` with this content:
+
+```rust
+//! Path conventions for the daemon's runtime artifacts.
+//!
+//! Two helpers live here:
+//! - [`history_path`] — the JSON file under `$XDG_CACHE_HOME` (with
+//!   `/tmp` fallback) that `--persist` mode round-trips.
+//! - [`status_path`] — the JSON file under `$XDG_RUNTIME_DIR` (with
+//!   `/tmp` fallback) that the waybar bell module reads.
+//!
+//! Co-located so the filename conventions sit in one place rather
+//! than spreading across the I/O modules that consume them.
+
+use std::path::PathBuf;
+
+/// Returns the path to the persisted notification history JSON file.
+/// Falls back to `/tmp` if the system can't resolve a cache dir.
+pub(crate) fn history_path() -> PathBuf {
+    nwg_common::config::paths::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("mac-notifications-history.json")
+}
+
+/// Returns the path to the waybar status JSON file.
+/// Falls back to `/tmp` if `XDG_RUNTIME_DIR` isn't set.
+pub(crate) fn status_path() -> PathBuf {
+    std::env::var("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+        .join("mac-notifications-status.json")
+}
+```
+
+- [ ] **Step 2: Declare the new module in `src/main.rs`**
+
+In `src/main.rs`, find the existing `mod` declarations at the top:
+
+```rust
+mod config;
+mod dbus;
+mod listeners;
+mod notification;
+mod persistence;
+mod state;
+mod ui;
+mod waybar;
+```
+
+Insert `mod paths;` alphabetically between `mod notification;` and `mod persistence;`:
+
+```rust
+mod config;
+mod dbus;
+mod listeners;
+mod notification;
+mod paths;
+mod persistence;
+mod state;
+mod ui;
+mod waybar;
+```
+
+- [ ] **Step 3: Update the `persistence::history_path()` call site in `main.rs`**
+
+In `src/main.rs`, find the line in `activate_notifications`:
+
+```rust
+    let history_path = persistence::history_path();
+```
+
+Replace with:
+
+```rust
+    let history_path = paths::history_path();
+```
+
+- [ ] **Step 4: Delete `history_path()` from `src/persistence.rs`**
+
+In `src/persistence.rs`, delete the function definition entirely:
+
+```rust
+/// Returns the path to the notification history file.
+pub(crate) fn history_path() -> PathBuf {
+    nwg_common::config::paths::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("mac-notifications-history.json")
+}
+```
+
+The remaining functions in `persistence.rs` (`load_history`, `save_history`) already take a `&Path` parameter, so no other edits are needed in this file.
+
+- [ ] **Step 5: Replace `status_path()` callers in `src/waybar.rs`**
+
+In `src/waybar.rs`, find the function definition:
+
+```rust
+/// Returns the path to the waybar status file.
+fn status_path() -> PathBuf {
+    std::env::var("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+        .join("mac-notifications-status.json")
+}
+```
+
+Delete it entirely.
+
+Then find the only call site, inside `update_status`:
+
+```rust
+    let path = status_path();
+```
+
+Replace with:
+
+```rust
+    let path = crate::paths::status_path();
+```
+
+- [ ] **Step 6: Drop the now-unused `PathBuf` import from `src/waybar.rs` if it's no longer referenced**
+
+After deleting `status_path()`, check whether `waybar.rs` still uses `PathBuf`:
+
+```bash
+grep -n "PathBuf" src/waybar.rs
+```
+
+If the only remaining hit is the `use std::path::PathBuf;` import line (no actual uses), delete that import line. If `PathBuf` is still used elsewhere in the file, leave the import alone.
+
+- [ ] **Step 7: Build, test, clippy, fmt**
+
+```bash
+cargo build
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean build; full 87-test suite still green (no test changes); clippy clean; no fmt drift.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/paths.rs src/main.rs src/persistence.rs src/waybar.rs
+git commit -m "$(cat <<'EOF'
+Extract history_path + status_path into a new paths module (#39)
+
+history_path() in persistence.rs and status_path() in waybar.rs
+were two near-identical "join a base dir against a fixed filename"
+helpers. Lifting them into a new src/paths.rs module puts the two
+runtime-artifact filenames in one place, so #34's eventual
+mac-notifications-* -> nwg-notifications-* rename is a single-file
+change instead of two-file synchronization.
+
+Both helpers keep their existing fallback semantics: history_path
+falls back to /tmp when nwg_common can't resolve a cache dir;
+status_path falls back to /tmp when XDG_RUNTIME_DIR isn't set.
+
+The persistence.rs callers (load_history, save_history) take a
+&Path parameter, so they didn't need an import update — only the
+single persistence::history_path() call site in main.rs moves to
+paths::history_path(). status_path's only caller is inside
+waybar::update_status, which now reads crate::paths::status_path().
+
+No behavioral change: cargo doc + cargo build clean, full 87-test
+suite still green, manual smoke confirms the daemon writes to the
+same paths it always did.
+
+Closes #39.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: #37 — Centralize `state.dnd` writes into `NotificationState::set_dnd`
+
+Five places currently mutate `state.dnd` (and sometimes `state.dnd_expires`). The signal handler in `listeners.rs::poll_signals` and the panel-header DND button in `ui/panel.rs::build_header` both leave `dnd_expires` stale when toggling — that's the latent bug the issue's AC test calls out. Routing every write through a single helper that takes `(enabled, expires)` makes the policy uniform and fixes the bug.
+
+**Files:**
+- Modify: `src/state.rs` — add `set_dnd` method, update existing test that direct-writes the field, add new test for the bug-fix path.
+- Modify: `src/listeners.rs` — replace the `ToggleDnd` arm's direct write with `set_dnd`.
+- Modify: `src/ui/panel.rs` — replace the panel-header button's direct write with `set_dnd`.
+- Modify: `src/ui/dnd_menu.rs` — replace 3 direct-write sites (toggle button, timed-DND button, timer-fire callback) with `set_dnd`.
+
+Note: `src/main.rs` initializes `state.borrow_mut().dnd = config.borrow().dnd;` at startup. That's a different shape (no log, no `on_state_change`, `dnd_expires` is already None from `NotificationState::new`) — it stays as-is.
+
+- [ ] **Step 1: Add `set_dnd` to `NotificationState` in `src/state.rs`**
+
+In `src/state.rs`, find the `impl NotificationState` block. Add this method just after `dismiss_all` and before `mark_read` (it sits with the other state-mutation methods):
+
+```rust
+    /// Sets DND mode and (optionally) the timed-DND expiry, then
+    /// logs the transition. The single writer for the `dnd` and
+    /// `dnd_expires` fields — every UI / signal / timer call site
+    /// routes through this so the two fields can never drift.
+    ///
+    /// Pass `expires = None` for a permanent toggle (the panel
+    /// header button, the signal handler, the menu's "until I turn
+    /// it off" entry, and the timer-fire that clears expired DND).
+    /// Pass `expires = Some(deadline)` only for the timed-DND menu
+    /// buttons that arm a `glib::timeout_add_local_once`.
+    pub(crate) fn set_dnd(&mut self, enabled: bool, expires: Option<std::time::SystemTime>) {
+        self.dnd = enabled;
+        self.dnd_expires = expires;
+        log::info!("DND {}", if enabled { "enabled" } else { "disabled" });
+    }
+```
+
+- [ ] **Step 2: Update the existing `dnd_suppresses_normal_popups` test to use the new helper**
+
+In `src/state.rs`, find the test (it sits in the `#[cfg(test)] mod tests` block):
+
+```rust
+    #[test]
+    fn dnd_suppresses_normal_popups() {
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
+        state.dnd = true;
+        assert!(!state.should_show_popup(Urgency::Normal));
+        assert!(!state.should_show_popup(Urgency::Low));
+        assert!(state.should_show_popup(Urgency::Critical));
+    }
+```
+
+Change the direct field assignment to a `set_dnd` call:
+
+```rust
+    #[test]
+    fn dnd_suppresses_normal_popups() {
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
+        state.set_dnd(true, None);
+        assert!(!state.should_show_popup(Urgency::Normal));
+        assert!(!state.should_show_popup(Urgency::Low));
+        assert!(state.should_show_popup(Urgency::Critical));
+    }
+```
+
+- [ ] **Step 3: Add the new test for the bug-fix scenario**
+
+In `src/state.rs`, append this test inside the `#[cfg(test)] mod tests` block (right after `dnd_suppresses_normal_popups`):
+
+```rust
+    #[test]
+    fn set_dnd_clears_stale_expiry_when_toggling_off() {
+        // Bug fix from #37: before the set_dnd helper landed, the
+        // signal handler in listeners.rs and the panel-header button
+        // in ui/panel.rs both flipped state.dnd directly without
+        // touching dnd_expires. So a user who armed timed DND from
+        // the menu (sets dnd=true + Some(expiry)) and then toggled
+        // DND off via the waybar bell signal would end up with
+        // dnd=false but dnd_expires=Some(stale). The set_dnd helper
+        // makes (enabled, expires) a single atomic write — the
+        // signal-handler path passes None, which clears the expiry.
+
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
+
+        // Arm timed DND (mirrors the dnd_menu timed-DND button path).
+        let expiry = SystemTime::now() + std::time::Duration::from_secs(3600);
+        state.set_dnd(true, Some(expiry));
+        assert!(state.dnd);
+        assert_eq!(state.dnd_expires, Some(expiry));
+
+        // Toggle off via signal (mirrors the listeners.rs ToggleDnd path).
+        state.set_dnd(false, None);
+        assert!(!state.dnd);
+        assert_eq!(
+            state.dnd_expires, None,
+            "toggling DND off via signal must clear stale dnd_expires"
+        );
+    }
+```
+
+- [ ] **Step 4: Update `src/listeners.rs` to use `set_dnd`**
+
+In `src/listeners.rs`, find the `ToggleDnd` arm (or the equivalent — look for the block where `state.borrow_mut().dnd = new_dnd;` is followed by a `log::info!("DND ..."` line). The current shape is roughly:
+
+```rust
+                    let new_dnd = !state.borrow().dnd;
+                    state.borrow_mut().dnd = new_dnd;
+                    log::info!(
+                        "DND {}",
+                        if new_dnd { "enabled" } else { "disabled" }
+                    );
+                    on_state_change();
+```
+
+Replace with:
+
+```rust
+                    let new_dnd = !state.borrow().dnd;
+                    state.borrow_mut().set_dnd(new_dnd, None);
+                    on_state_change();
+```
+
+The `log::info!` call is now redundant — `set_dnd` does the same log line internally — so it's deleted along with the direct-write line.
+
+- [ ] **Step 5: Update `src/ui/panel.rs` to use `set_dnd`**
+
+In `src/ui/panel.rs`, find the panel-header DND button click handler (`dnd_btn.connect_clicked(move |btn| { ... })`). The current block:
+
+```rust
+    dnd_btn.connect_clicked(move |btn| {
+        let new_dnd = !state_dnd.borrow().dnd;
+        state_dnd.borrow_mut().dnd = new_dnd;
+        let icon = if new_dnd {
+            "notifications-disabled-symbolic"
+        } else {
+            "preferences-system-notifications-symbolic"
+        };
+        btn.set_icon_name(icon);
+        log::info!("DND {}", if new_dnd { "enabled" } else { "disabled" });
+        on_change_dnd();
+    });
+```
+
+Replace the `state_dnd.borrow_mut().dnd = new_dnd;` line and the trailing `log::info!` line with a single `set_dnd` call. The icon-update lines stay (UI-specific, out of `set_dnd`'s scope). New shape:
+
+```rust
+    dnd_btn.connect_clicked(move |btn| {
+        let new_dnd = !state_dnd.borrow().dnd;
+        state_dnd.borrow_mut().set_dnd(new_dnd, None);
+        let icon = if new_dnd {
+            "notifications-disabled-symbolic"
+        } else {
+            "preferences-system-notifications-symbolic"
+        };
+        btn.set_icon_name(icon);
+        on_change_dnd();
+    });
+```
+
+- [ ] **Step 6: Update the DND-menu toggle button in `src/ui/dnd_menu.rs`**
+
+In `src/ui/dnd_menu.rs`, find the toggle-button click handler. Current shape:
+
+```rust
+        toggle_btn.connect_clicked(move |_| {
+            let new_dnd = !state_toggle.borrow().dnd;
+            state_toggle.borrow_mut().dnd = new_dnd;
+            state_toggle.borrow_mut().dnd_expires = None;
+            log::info!("DND {}", if new_dnd { "enabled" } else { "disabled" });
+            on_change_toggle();
+            win_toggle.set_visible(false);
+            for b in &backdrops_toggle {
+                b.set_visible(false);
+            }
+        });
+```
+
+Replace the two `state_toggle.borrow_mut().dnd = ...` / `dnd_expires = ...` writes and the `log::info!` line with one `set_dnd` call:
+
+```rust
+        toggle_btn.connect_clicked(move |_| {
+            let new_dnd = !state_toggle.borrow().dnd;
+            state_toggle.borrow_mut().set_dnd(new_dnd, None);
+            on_change_toggle();
+            win_toggle.set_visible(false);
+            for b in &backdrops_toggle {
+                b.set_visible(false);
+            }
+        });
+```
+
+- [ ] **Step 7: Update the timed-DND button (the one that arms the timer)**
+
+In `src/ui/dnd_menu.rs::build_timed_dnd_button`, find the `btn.connect_clicked(move |_| { ... })` block. The change reorders two existing lines: the `expiry` calculation moves *up* so it can be passed to `set_dnd` and reused by the captured token. Current shape:
+
+```rust
+    btn.connect_clicked(move |_| {
+        state_btn.borrow_mut().dnd = true;
+        let expiry = std::time::SystemTime::now() + std::time::Duration::from_secs(minutes * 60);
+        state_btn.borrow_mut().dnd_expires = Some(expiry);
+        log::info!("DND enabled for {} minutes", minutes);
+
+        // Capture the expiry we just stored. If the user clicks a
+        // different duration before this timer fires, the stored
+        // expiry will have been replaced; this timer's `expiry` token
+        // won't match and the firing will no-op. Cleaner than
+        // tracking a glib::SourceId and removing the previous source
+        // (no removal lifetime concerns).
+        let captured_expiry = expiry;
+        let state_timer = Rc::clone(&state_btn);
+        let on_change_timer = Rc::clone(&on_change);
+        gtk4::glib::timeout_add_local_once(
+            std::time::Duration::from_secs(minutes * 60),
+            move || {
+                let current = state_timer.borrow().dnd_expires;
+                if current == Some(captured_expiry) {
+                    state_timer.borrow_mut().dnd = false;
+                    state_timer.borrow_mut().dnd_expires = None;
+                    log::info!("Timed DND expired");
+                    on_change_timer();
+                }
+                // else: a newer schedule replaced this one; no-op silently.
+            },
+        );
+
+        on_change();
+        win_btn.set_visible(false);
+        for b in &backdrops_btn {
+            b.set_visible(false);
+        }
+    });
+```
+
+Replace the two `state_btn.borrow_mut().*` writes plus the `log::info!` line at the top with: hoist the `expiry` calculation, then one `set_dnd` call. Keep the duration-specific `log::info!("DND enabled for {} minutes", minutes)` because `set_dnd`'s generic `"DND enabled"` log doesn't capture which duration the user chose. New shape (only the top of the closure changes; the `captured_expiry` / timer-arm / visibility-cleanup tail in this step remains as-is — Step 8 updates the timer-fire body):
+
+```rust
+    btn.connect_clicked(move |_| {
+        let expiry = std::time::SystemTime::now() + std::time::Duration::from_secs(minutes * 60);
+        state_btn.borrow_mut().set_dnd(true, Some(expiry));
+        log::info!("DND enabled for {} minutes", minutes);
+
+        // Capture the expiry we just stored. If the user clicks a
+        // different duration before this timer fires, the stored
+        // expiry will have been replaced; this timer's `expiry` token
+        // won't match and the firing will no-op. Cleaner than
+        // tracking a glib::SourceId and removing the previous source
+        // (no removal lifetime concerns).
+        let captured_expiry = expiry;
+        let state_timer = Rc::clone(&state_btn);
+        let on_change_timer = Rc::clone(&on_change);
+        gtk4::glib::timeout_add_local_once(
+            std::time::Duration::from_secs(minutes * 60),
+            move || {
+                let current = state_timer.borrow().dnd_expires;
+                if current == Some(captured_expiry) {
+                    state_timer.borrow_mut().dnd = false;
+                    state_timer.borrow_mut().dnd_expires = None;
+                    log::info!("Timed DND expired");
+                    on_change_timer();
+                }
+                // else: a newer schedule replaced this one; no-op silently.
+            },
+        );
+
+        on_change();
+        win_btn.set_visible(false);
+        for b in &backdrops_btn {
+            b.set_visible(false);
+        }
+    });
+```
+
+- [ ] **Step 8: Update the timer-fire callback inside `build_timed_dnd_button`**
+
+Still in `src/ui/dnd_menu.rs::build_timed_dnd_button`, find the `gtk4::glib::timeout_add_local_once` block. Current shape:
+
+```rust
+        gtk4::glib::timeout_add_local_once(
+            std::time::Duration::from_secs(minutes * 60),
+            move || {
+                let current = state_timer.borrow().dnd_expires;
+                if current == Some(captured_expiry) {
+                    state_timer.borrow_mut().dnd = false;
+                    state_timer.borrow_mut().dnd_expires = None;
+                    log::info!("Timed DND expired");
+                    on_change_timer();
+                }
+                // else: a newer schedule replaced this one; no-op silently.
+            },
+        );
+```
+
+Replace the two `state_timer.borrow_mut().*` writes plus the `log::info!` line with one `set_dnd` call. Keep the explicit `"Timed DND expired"` log line since `set_dnd`'s generic `"DND disabled"` doesn't capture the "via expiry timer" provenance:
+
+```rust
+        gtk4::glib::timeout_add_local_once(
+            std::time::Duration::from_secs(minutes * 60),
+            move || {
+                let current = state_timer.borrow().dnd_expires;
+                if current == Some(captured_expiry) {
+                    state_timer.borrow_mut().set_dnd(false, None);
+                    log::info!("Timed DND expired");
+                    on_change_timer();
+                }
+                // else: a newer schedule replaced this one; no-op silently.
+            },
+        );
+```
+
+- [ ] **Step 9: Build, test, clippy, fmt**
+
+```bash
+cargo build
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean build; full suite passes with the new test bringing the count to 88 (87 → 88); clippy clean; no fmt drift.
+
+The new `set_dnd_clears_stale_expiry_when_toggling_off` test should appear in the test output and pass.
+
+- [ ] **Step 10: Confirm the `dnd` and `dnd_expires` fields have no remaining direct writers in production code**
+
+```bash
+grep -rn "\.dnd\s*=\s*\|\.dnd_expires\s*=\s*" src/ --include="*.rs" | grep -v "tests"
+```
+
+Expected: only one match — `src/main.rs:172` (the startup initialization `state.borrow_mut().dnd = config.borrow().dnd;`). That's the one direct write that intentionally stays — it sits inside `activate_notifications` before the daemon is wired up, has no `on_state_change` to fire, and `dnd_expires` is already `None` from `NotificationState::new`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/state.rs src/listeners.rs src/ui/panel.rs src/ui/dnd_menu.rs
+git commit -m "$(cat <<'EOF'
+Centralize state.dnd writes via NotificationState::set_dnd (#37)
+
+Five places currently mutate state.dnd (sometimes alongside
+state.dnd_expires) with three slightly-different side-effect
+patterns. The signal handler in listeners.rs and the panel-header
+DND button in ui/panel.rs both leave dnd_expires stale when
+toggling — a latent bug because a user who armed timed DND from
+the menu and then toggled DND off via the waybar bell would end
+up with dnd=false but dnd_expires=Some(stale).
+
+Add NotificationState::set_dnd(enabled, expires) as the single
+writer of both fields. Each caller passes the expiry it wants:
+- listeners.rs ToggleDnd: passes None (signal toggles always
+  clear timed expiry — fixes the bug)
+- ui/panel.rs panel-header DND button: passes None (same fix)
+- ui/dnd_menu.rs toggle button: passes None (already cleared
+  expiry, now does it via the helper)
+- ui/dnd_menu.rs timed-DND button: passes Some(expiry)
+- ui/dnd_menu.rs timer-fire callback: passes None
+
+Logging moves into the helper so all sites get a consistent "DND
+enabled/disabled" line. Two sites keep an additional log::info
+call for context the helper can't capture (the timed-DND duration
+in minutes; the "Timed DND expired" provenance for the timer fire).
+
+The startup initialization in main.rs (state.borrow_mut().dnd =
+config.borrow().dnd) intentionally stays as a direct field write
+— it runs before the daemon is wired up, has no on_state_change
+to fire, and dnd_expires is already None from
+NotificationState::new.
+
+New unit test set_dnd_clears_stale_expiry_when_toggling_off pins
+the bug-fix scenario: arm timed DND, toggle off via the
+signal-handler path, assert dnd_expires is cleared. The existing
+dnd_suppresses_normal_popups test now exercises set_dnd as well.
+
+Test count: 87 -> 88.
+
+Closes #37.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Pre-PR gates + smoke install
+
+Per repo convention. This bundle is internal refactor + one latent-bug fix, so the smoke focuses on the DND state machine — particularly the bug-fix path that the unit test exercises.
+
+- [ ] **Step 1: Install to user bin and confirm restart works**
+
+```bash
+make upgrade PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+```
+
+Expected: build → install → kill running daemon → respawn. `pidof nwg-notifications` returns the new PID.
+
+- [ ] **Step 2: Hand off to the user — STOP HERE**
+
+Tell the user (verbatim or close):
+
+> Installed and restarted via `make upgrade`. This bundle adds the
+> `set_dnd` helper + the `paths` module, no behavior change except
+> the latent stale-`dnd_expires` bug fix. Smoke:
+>
+> 1. `notify-send "smoke" "test"` — popup appears (verifies
+>    nothing in the I/O paths broke from the `paths` module move).
+> 2. Right-click the waybar bell to open the DND menu, click
+>    "1 hour". Bell glyph flips to bell-off.
+> 3. Now toggle DND off via the SIGRTMIN+5 signal (or the panel
+>    header DND button if you have it). Bell glyph flips back.
+>    Then re-enable timed DND from the menu — should still work
+>    cleanly without an old timer racing to clear it (this is the
+>    #37 bug-fix scenario).
+> 4. Open the panel — history entries still load from the
+>    persisted file (verifies the `history_path` move).
+>
+> Reply when satisfied.
+
+**Do not proceed to Task 4 until the user explicitly approves.**
+
+- [ ] **Step 3: Full lint after smoke approval**
+
+```bash
+make lint
+```
+
+Expected: every step exits 0; total test count is 88.
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin chore/state-refactor-37-39
+```
+
+---
+
+## Task 4: Open PR
+
+- [ ] **Step 1: Open the PR**
+
+```bash
+gh pr create --base main --head chore/state-refactor-37-39 \
+  --title "Bundle state refactor: #37 #39" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Bundles two internal-state refactors from epic #29 into one PR:
+
+- **#39** — Lifted \`history_path\` (was in \`src/persistence.rs\`) and \`status_path\` (was in \`src/waybar.rs\`) into a new \`src/paths.rs\` module. The two filename conventions now sit together; #34's eventual \`mac-notifications-*\` → \`nwg-notifications-*\` rename is a single-file change. \`persistence.rs\` and \`waybar.rs\` shrink slightly; the only call-site change in \`main.rs\` is \`persistence::history_path()\` → \`paths::history_path()\`.
+- **#37** — Added \`NotificationState::set_dnd(enabled, expires)\` as the single writer for the \`dnd\` and \`dnd_expires\` fields. Routed all 5 write sites through it (\`listeners.rs::poll_signals\` ToggleDnd arm, \`ui/panel.rs\` panel-header DND button, and 3 sites in \`ui/dnd_menu.rs\`: toggle button, timed-DND button, timer-fire callback). Logging moves into the helper. **Latent bug fix:** the signal-handler and panel-header paths used to leave \`dnd_expires\` stale when toggling off — now they pass \`None\` and clear it atomically. The startup initialization in \`main.rs\` keeps its direct field write (no \`on_state_change\` to fire, runs before the daemon is wired).
+
+One commit per issue. No CHANGELOG entry — the bug fix is a latent issue (mostly harmless because the timer-fire token check makes the stale expiry a no-op).
+
+## Test plan
+
+- [x] \`make lint\` clean locally (fmt + clippy + test + deny + audit). Test count: 87 → 88 (+1 for the #37 bug-fix test).
+- [x] Manual smoke test against the live compositor (installed via \`make upgrade PREFIX=\$HOME/.local BINDIR=\$HOME/.cargo/bin\`):
+  - [x] \`notify-send\` produces a popup; persisted history still round-trips.
+  - [x] Arm timed DND from the menu, toggle off via signal, re-enable from menu — no stale timer races to clear it.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CodeRabbit + iterate**
+
+Default-fix posture per repo convention. Inline reply per in-diff comment, single PR-level reply for outside-diff items, tag \`@coderabbitai\` every time. Do not respond to non-bot commenters under the maintainer's account.
+
+---
+
+## Notes
+
+- **No CHANGELOG entry.** Pure internal refactor + a latent bug fix that's never been reported (the stale `dnd_expires` is mostly harmless because of the timer-fire token check landed in #31).
+- **Why `set_dnd` and not `toggle_dnd`?** The callers each compute `new_dnd = !current` themselves and pass it in explicitly. Keeps the helper free of "what does toggle mean if expiry is also passed?" ambiguity. Each caller's intent reads cleanly (`set_dnd(true, Some(expiry))` is unambiguous; `toggle_dnd(Some(expiry))` would beg the question of what happens to the expiry on the OFF half of the toggle).
+- **Why doesn't `set_dnd` fire `on_state_change` itself?** The callback is a `Rc<dyn Fn()>` owned by the call site, not by `NotificationState`. Threading it through every `set_dnd` call would mean either storing it on the state struct (couples state-mutation to the signal-out side) or passing it as a third parameter (clutters the signature). Leaving the call sites to fire `on_state_change` after `set_dnd` is the simpler shape.

--- a/docs/superpowers/plans/2026-05-03-bundle-state-refactor-37-39.md
+++ b/docs/superpowers/plans/2026-05-03-bundle-state-refactor-37-39.md
@@ -568,7 +568,7 @@ The new `set_dnd_clears_stale_expiry_when_toggling_off` test should appear in th
 grep -rn "\.dnd\s*=\s*\|\.dnd_expires\s*=\s*" src/ --include="*.rs" | grep -v "tests"
 ```
 
-Expected: only one match — `src/main.rs:172` (the startup initialization `state.borrow_mut().dnd = config.borrow().dnd;`). That's the one direct write that intentionally stays — it sits inside `activate_notifications` before the daemon is wired up, has no `on_state_change` to fire, and `dnd_expires` is already `None` from `NotificationState::new`.
+Expected: only one match — the startup initialization `state.borrow_mut().dnd = config.borrow().dnd;` inside `activate_notifications` in `src/main.rs`. That's the one direct write that intentionally stays — it runs before the daemon is wired up, has no `on_state_change` to fire, and `dnd_expires` is already `None` from `NotificationState::new`.
 
 - [ ] **Step 11: Commit**
 

--- a/docs/superpowers/plans/2026-05-03-bundle-state-refactor-37-39.md
+++ b/docs/superpowers/plans/2026-05-03-bundle-state-refactor-37-39.md
@@ -16,7 +16,7 @@
 
 | Task | Files modified | Test approach |
 |------|----------------|---------------|
-| #39 paths module | New `src/paths.rs` (lifts both helpers); `src/main.rs` (declares `mod paths;`); `src/persistence.rs` (drops `history_path`, imports from `paths`); `src/waybar.rs` (drops `status_path`, imports from `paths`); `src/main.rs` (call site `persistence::history_path()` → `paths::history_path()`) | `cargo build --release` clean; `make lint` green; daemon still writes the same files |
+| #39 paths module | New `src/paths.rs` (lifts both helpers, **with per-UID `/tmp/nwg-notifications-<uid>/` mode-0700 sandbox + symlink/foreign-owner refusal as the degraded-environment fallback** — not raw `/tmp`); `src/main.rs` (declares `mod paths;`); `src/persistence.rs` (drops `history_path`); `src/waybar.rs` (drops `status_path`); `src/main.rs` (call site `persistence::history_path()` → `paths::history_path()`) | New `#[cfg(test)] mod tests` covers the four fallback cases (XDG_RUNTIME_DIR / XDG_CACHE_HOME / cache_dir-falls-through / per-UID sandbox) plus a `try_create_or_validate` safety-check refusal test; `make lint` green |
 | #37 set_dnd helper | `src/state.rs` (add `set_dnd` method, update existing test write site, add new unit test); `src/listeners.rs` (`ToggleDnd` arm); `src/ui/panel.rs` (panel header DND button); `src/ui/dnd_menu.rs` (3 sites: toggle, timed-DND button, timer-fire) | New unit test asserts the bug fix: enabling timed DND then toggling via signal correctly clears `dnd_expires` |
 
 Each issue gets its own commit. No CHANGELOG entry — internal refactor; the bug fix in #37 is a latent issue that's never been reported (the stale `dnd_expires` is mostly harmless because the timer-fire token check makes it a no-op if the user cycles quickly enough; worst case the timer fires later and re-clears DND that's already off, which is invisible).
@@ -62,6 +62,13 @@ Expected: every step exits 0; pre-existing `cargo deny` "unmatched skip" warning
 - Modify: `src/main.rs` — add `mod paths;` declaration alongside the existing `mod` lines + update the `persistence::history_path()` call site
 - Modify: `src/persistence.rs` — delete the local `history_path()` function (its body moves to `paths`); the file shouldn't import `paths` itself since `load_history` and `save_history` already take a `&Path` parameter
 - Modify: `src/waybar.rs` — delete the local `status_path()` function; the call site in `update_status` switches to `crate::paths::status_path()`
+
+**Note on the implementation that actually shipped:** the snippet below shows the bare-bones initial cut to keep the step focused. Two follow-up CodeRabbit findings on PR #58 hardened it before merge:
+- The `/tmp` fallback became a per-UID sandbox `/tmp/nwg-notifications-<uid>/` created with mode `0700` via atomic `mkdir(2)`. On `AlreadyExists` the helper validates `is_dir + owned_by_uid + mode == 0700` and refuses (falling through to a per-PID variant) if any check fails. Defends against symlink-clobber and foreign-owned-dir attacks the bare `/tmp/...` form was vulnerable to.
+- `XDG_RUNTIME_DIR=""` is filtered as if unset (otherwise `PathBuf::from("")` resolves status path against CWD).
+- A `#[cfg(test)] mod tests` covers all four fallback cases serially via a `Mutex<()>`, plus a `try_create_or_validate` safety-check refusal test.
+
+If you're re-running this plan from scratch on a fresh branch, prefer the hardened shape that's currently in `src/paths.rs` over the snippet below — the snippet stays as the *minimal first commit* that this plan originally produced; the hardening shipped as follow-up commits in the same PR.
 
 - [ ] **Step 1: Create `src/paths.rs`**
 
@@ -253,7 +260,7 @@ Five places currently mutate `state.dnd` (and sometimes `state.dnd_expires`). Th
 - Modify: `src/ui/panel.rs` — replace the panel-header button's direct write with `set_dnd`.
 - Modify: `src/ui/dnd_menu.rs` — replace 3 direct-write sites (toggle button, timed-DND button, timer-fire callback) with `set_dnd`.
 
-Note: `src/main.rs` initializes `state.borrow_mut().dnd = config.borrow().dnd;` at startup. That's a different shape (no log, no `on_state_change`, `dnd_expires` is already None from `NotificationState::new`) — it stays as-is.
+Note: `src/main.rs` initially kept the startup write as a direct field assignment (`state.borrow_mut().dnd = config.borrow().dnd;`) — it runs before the daemon is wired up, has no `on_state_change` to fire, and `dnd_expires` is already `None` from `NotificationState::new`. **That decision was reversed by a CodeRabbit follow-up on PR #58:** the `dnd` and `dnd_expires` fields are now fully private (the rabbit's "enforce the invariant at the type boundary" finding), so the startup init now reads `state.borrow_mut().set_dnd(initial_dnd, None)`. Cost: the daemon logs a `"DND enabled/disabled"` line at startup confirming whether `--dnd` was passed. Harmless and arguably useful.
 
 - [ ] **Step 1: Add `set_dnd` to `NotificationState` in `src/state.rs`**
 
@@ -568,7 +575,7 @@ The new `set_dnd_clears_stale_expiry_when_toggling_off` test should appear in th
 grep -rn "\.dnd\s*=\s*\|\.dnd_expires\s*=\s*" src/ --include="*.rs" | grep -v "tests"
 ```
 
-Expected: only one match — the startup initialization `state.borrow_mut().dnd = config.borrow().dnd;` inside `activate_notifications` in `src/main.rs`. That's the one direct write that intentionally stays — it runs before the daemon is wired up, has no `on_state_change` to fire, and `dnd_expires` is already `None` from `NotificationState::new`.
+Expected: only writes inside the `set_dnd` body itself (`self.dnd = enabled;` and `self.dnd_expires = ...;`). The startup initialization in `activate_notifications` (`src/main.rs`) was originally planned to keep its direct field write, but a follow-up CodeRabbit finding on PR #58 made the fields fully private and added accessors — the startup init now reads `state.borrow_mut().set_dnd(initial_dnd, None)` so the privatization is enforced everywhere. The field privacy is module-scoped (`#[cfg(test)] mod tests` in `src/state.rs` can still touch the fields directly).
 
 - [ ] **Step 11: Commit**
 

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -99,7 +99,7 @@ pub(crate) fn poll_signals(
                     panel.borrow().toggle();
                 }
                 NotificationCommand::ToggleDnd => {
-                    let new_dnd = !state.borrow().dnd;
+                    let new_dnd = !state.borrow().is_dnd_enabled();
                     state.borrow_mut().set_dnd(new_dnd, None);
                     log::debug!("DND toggled via signal");
                     on_change();

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -100,11 +100,8 @@ pub(crate) fn poll_signals(
                 }
                 NotificationCommand::ToggleDnd => {
                     let new_dnd = !state.borrow().dnd;
-                    state.borrow_mut().dnd = new_dnd;
-                    log::info!(
-                        "DND {} via signal",
-                        if new_dnd { "enabled" } else { "disabled" }
-                    );
+                    state.borrow_mut().set_dnd(new_dnd, None);
+                    log::debug!("DND toggled via signal");
                     on_change();
                 }
                 NotificationCommand::ShowDndMenu => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod config;
 mod dbus;
 mod listeners;
 mod notification;
+mod paths;
 mod persistence;
 mod state;
 mod ui;
@@ -172,7 +173,7 @@ fn activate_notifications(
     state.borrow_mut().dnd = config.borrow().dnd;
 
     // Load persisted history
-    let history_path = persistence::history_path();
+    let history_path = paths::history_path();
     if config.borrow().persist {
         let loaded = persistence::load_history(&history_path);
         if !loaded.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,12 @@ fn activate_notifications(
         app_dirs,
         Rc::clone(config),
     )));
-    state.borrow_mut().dnd = config.borrow().dnd;
+    // Initialize DND from CLI flag. Routes through set_dnd so the
+    // (dnd, dnd_expires) write stays atomic now that the fields
+    // are private; the helper's log line at startup is harmless and
+    // confirms in the journal whether the user passed --dnd.
+    let initial_dnd = config.borrow().dnd;
+    state.borrow_mut().set_dnd(initial_dnd, None);
 
     // Load persisted history
     let history_path = paths::history_path();
@@ -190,7 +195,7 @@ fn activate_notifications(
 
     // Write initial waybar status
     let s = state.borrow();
-    waybar::update_status(s.unread_count(), s.dnd);
+    waybar::update_status(s.unread_count(), s.is_dnd_enabled());
     drop(s);
 
     // Shared callback for any state change -> save history + update waybar
@@ -275,7 +280,7 @@ fn build_state_change_callback(
         let s = state_sync.borrow();
         let unread = s.unread_count();
         let count = dbus::unread_count_to_u32(unread);
-        waybar::update_status(unread, s.dnd);
+        waybar::update_status(unread, s.is_dnd_enabled());
         if persist {
             persistence::save_history(&history_path, &s.history);
         }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -23,6 +23,14 @@
 
 use std::path::PathBuf;
 
+/// Mask isolating the standard Unix permission bits (owner +
+/// group + other × read/write/execute) from the rest of the
+/// `st_mode` field returned by `stat(2)` (which also encodes
+/// file type and the setuid/setgid/sticky bits we don't care
+/// about here). Used wherever we compare a `mode()` reading
+/// against `FALLBACK_DIR_MODE`.
+const PERMISSION_BITS_MASK: u32 = 0o777;
+
 /// Permission mode for the per-UID `/tmp` fallback sandbox dir.
 /// `0o700` = owner read/write/execute, no access for group or other.
 /// Both required: `r/w` for the daemon to manage its files, `x` to
@@ -182,7 +190,7 @@ fn try_create_or_validate(dir: &std::path::Path, uid: libc::uid_t) -> bool {
                 Ok(meta) => {
                     let is_dir = meta.file_type().is_dir();
                     let owned = meta.uid() == uid;
-                    let mode = meta.permissions().mode() & 0o777;
+                    let mode = meta.permissions().mode() & PERMISSION_BITS_MASK;
                     if is_dir && owned && mode == FALLBACK_DIR_MODE {
                         return true;
                     }
@@ -327,7 +335,7 @@ mod tests {
             .expect("fallback dir created")
             .permissions()
             .mode()
-            & 0o777;
+            & PERMISSION_BITS_MASK;
         assert_eq!(
             mode, FALLBACK_DIR_MODE,
             "fallback dir must be mode {:o} to bound cross-user reads, got {mode:o}",

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,29 @@
+//! Path conventions for the daemon's runtime artifacts.
+//!
+//! Two helpers live here:
+//! - [`history_path`] — the JSON file under `$XDG_CACHE_HOME` (with
+//!   `/tmp` fallback) that `--persist` mode round-trips.
+//! - [`status_path`] — the JSON file under `$XDG_RUNTIME_DIR` (with
+//!   `/tmp` fallback) that the waybar bell module reads.
+//!
+//! Co-located so the filename conventions sit in one place rather
+//! than spreading across the I/O modules that consume them.
+
+use std::path::PathBuf;
+
+/// Returns the path to the persisted notification history JSON file.
+/// Falls back to `/tmp` if the system can't resolve a cache dir.
+pub(crate) fn history_path() -> PathBuf {
+    nwg_common::config::paths::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("mac-notifications-history.json")
+}
+
+/// Returns the path to the waybar status JSON file.
+/// Falls back to `/tmp` if `XDG_RUNTIME_DIR` isn't set.
+pub(crate) fn status_path() -> PathBuf {
+    std::env::var("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+        .join("mac-notifications-status.json")
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -23,6 +23,16 @@
 
 use std::path::PathBuf;
 
+/// Permission mode for the per-UID `/tmp` fallback sandbox dir.
+/// `0o700` = owner read/write/execute, no access for group or other.
+/// Both required: `r/w` for the daemon to manage its files, `x` to
+/// open files inside the dir at all. Group/other are denied so a
+/// permissive umask on a created file still leaves cross-user reads
+/// blocked at the parent-dir level. Named so the create site, the
+/// validation check, and the unit-test assertion share one source
+/// of truth.
+const FALLBACK_DIR_MODE: u32 = 0o700;
+
 /// Returns the path to the persisted notification history JSON file.
 /// Prefers `nwg_common`'s XDG-aware cache dir; falls back to a
 /// per-UID sandbox under `/tmp` if no XDG cache dir resolves.
@@ -123,7 +133,10 @@ fn fallback_user_dir_from(cache_dir: Option<PathBuf>) -> PathBuf {
 /// logs an error.
 fn try_create_or_validate(dir: &std::path::Path, uid: libc::uid_t) -> bool {
     use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
-    match std::fs::DirBuilder::new().mode(0o700).create(dir) {
+    match std::fs::DirBuilder::new()
+        .mode(FALLBACK_DIR_MODE)
+        .create(dir)
+    {
         Ok(()) => true,
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
             match std::fs::symlink_metadata(dir) {
@@ -131,13 +144,14 @@ fn try_create_or_validate(dir: &std::path::Path, uid: libc::uid_t) -> bool {
                     let is_dir = meta.file_type().is_dir();
                     let owned = meta.uid() == uid;
                     let mode = meta.permissions().mode() & 0o777;
-                    if is_dir && owned && mode == 0o700 {
+                    if is_dir && owned && mode == FALLBACK_DIR_MODE {
                         return true;
                     }
                     log::error!(
                         "Fallback dir {} fails safety checks (is_dir={is_dir}, \
-                         owned_by_us={owned}, mode={mode:o} expected 0700). Refusing to use.",
-                        dir.display()
+                         owned_by_us={owned}, mode={mode:o} expected {:o}). Refusing to use.",
+                        dir.display(),
+                        FALLBACK_DIR_MODE
                     );
                     false
                 }
@@ -254,9 +268,9 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(
-            mode, 0o700,
-            "fallback dir must be mode 0700 to bound cross-user reads, got {:o}",
-            mode
+            mode, FALLBACK_DIR_MODE,
+            "fallback dir must be mode {:o} to bound cross-user reads, got {mode:o}",
+            FALLBACK_DIR_MODE
         );
 
         // Cleanup.

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,29 +1,83 @@
 //! Path conventions for the daemon's runtime artifacts.
 //!
 //! Two helpers live here:
-//! - [`history_path`] — the JSON file under `$XDG_CACHE_HOME` (with
-//!   `/tmp` fallback) that `--persist` mode round-trips.
-//! - [`status_path`] — the JSON file under `$XDG_RUNTIME_DIR` (with
-//!   `/tmp` fallback) that the waybar bell module reads.
+//! - [`history_path`] — the JSON file under `$XDG_CACHE_HOME` that
+//!   `--persist` mode round-trips.
+//! - [`status_path`] — the JSON file under `$XDG_RUNTIME_DIR` that
+//!   the waybar bell module reads.
 //!
 //! Co-located so the filename conventions sit in one place rather
 //! than spreading across the I/O modules that consume them.
+//!
+//! **Fallbacks are per-user, not `/tmp`.** Both helpers prefer the
+//! XDG-resolved directory, then fall through to
+//! `nwg_common::config::paths::cache_dir()` (which itself walks
+//! `XDG_CACHE_HOME` → `dirs::cache_dir()`). Only when even that
+//! fails do we reach for `/tmp`, and even then we sandbox into a
+//! per-UID subdirectory with mode `0700` — never the world-writable
+//! root of `/tmp` directly. Writing notification history or the
+//! waybar status JSON to `/tmp/mac-notifications-*.json` would
+//! expose them to symlink-clobber attacks (an attacker pre-creating
+//! the path as a symlink to a victim file) and to cross-user reads
+//! under permissive umasks. The per-UID subdir bounds both.
 
 use std::path::PathBuf;
 
 /// Returns the path to the persisted notification history JSON file.
-/// Falls back to `/tmp` if the system can't resolve a cache dir.
+/// Prefers `nwg_common`'s XDG-aware cache dir; falls back to a
+/// per-UID sandbox under `/tmp` if no XDG cache dir resolves.
 pub(crate) fn history_path() -> PathBuf {
-    nwg_common::config::paths::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("mac-notifications-history.json")
+    fallback_user_dir().join("mac-notifications-history.json")
 }
 
 /// Returns the path to the waybar status JSON file.
-/// Falls back to `/tmp` if `XDG_RUNTIME_DIR` isn't set.
+/// Prefers `$XDG_RUNTIME_DIR`; falls back to `cache_dir()` and
+/// finally to a per-UID sandbox under `/tmp` if neither resolves.
 pub(crate) fn status_path() -> PathBuf {
     std::env::var("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+        .unwrap_or_else(|_| fallback_user_dir())
         .join("mac-notifications-status.json")
+}
+
+/// Returns a directory the current user owns and can write to.
+/// Tries `cache_dir()` first; if that fails (no `$HOME`, no
+/// `$XDG_CACHE_HOME`), creates and returns
+/// `/tmp/nwg-notifications-<uid>/` with mode `0700`. The per-UID
+/// subdirectory bounds two attacks that the previous bare-`/tmp`
+/// fallback was vulnerable to:
+/// - **Symlink-clobber on write.** An attacker who can predict the
+///   filename `/tmp/mac-notifications-history.json` could
+///   pre-create it as a symlink to a victim file before the daemon
+///   writes. Putting the file inside `/tmp/nwg-notifications-<uid>/`
+///   means the attacker would have to win the same race for a
+///   directory they don't own.
+/// - **Cross-user reads.** `std::fs::write` honors the process
+///   umask, which on permissive systems leaves the file
+///   world-readable. Mode `0700` on the parent dir blocks reads
+///   regardless of file mode.
+fn fallback_user_dir() -> PathBuf {
+    if let Some(dir) = nwg_common::config::paths::cache_dir() {
+        return dir;
+    }
+    // SAFETY: `getuid()` is documented to always succeed and never
+    // return an error per POSIX. The `unsafe` is purely the FFI tag.
+    let uid = unsafe { libc::getuid() };
+    let dir = PathBuf::from("/tmp").join(format!("nwg-notifications-{uid}"));
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::error!(
+            "Failed to create per-user fallback dir {}: {}",
+            dir.display(),
+            e
+        );
+    }
+    use std::os::unix::fs::PermissionsExt;
+    if let Err(e) = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)) {
+        log::warn!(
+            "Failed to set 0700 perms on fallback dir {}: {}",
+            dir.display(),
+            e
+        );
+    }
+    dir
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -42,10 +42,10 @@ pub(crate) fn status_path() -> PathBuf {
 
 /// Returns a directory the current user owns and can write to.
 /// Tries `cache_dir()` first; if that fails (no `$HOME`, no
-/// `$XDG_CACHE_HOME`), creates and returns
-/// `/tmp/nwg-notifications-<uid>/` with mode `0700`. The per-UID
-/// subdirectory bounds two attacks that the previous bare-`/tmp`
-/// fallback was vulnerable to:
+/// `$XDG_CACHE_HOME`, and no `/etc/passwd` entry resolvable via
+/// `getpwuid_r`), creates and returns `/tmp/nwg-notifications-<uid>/`
+/// with mode `0700`. The per-UID subdirectory bounds two attacks
+/// that the previous bare-`/tmp` fallback was vulnerable to:
 /// - **Symlink-clobber on write.** An attacker who can predict the
 ///   filename `/tmp/mac-notifications-history.json` could
 ///   pre-create it as a symlink to a victim file before the daemon
@@ -57,7 +57,15 @@ pub(crate) fn status_path() -> PathBuf {
 ///   world-readable. Mode `0700` on the parent dir blocks reads
 ///   regardless of file mode.
 fn fallback_user_dir() -> PathBuf {
-    if let Some(dir) = nwg_common::config::paths::cache_dir() {
+    fallback_user_dir_from(nwg_common::config::paths::cache_dir())
+}
+
+/// Inner helper: parameterized over the resolved cache dir so unit
+/// tests can simulate the "no cache dir" branch without mocking
+/// the global `dirs::cache_dir()` lookup (which traverses
+/// `/etc/passwd` and is hard to neutralize via env vars alone).
+fn fallback_user_dir_from(cache_dir: Option<PathBuf>) -> PathBuf {
+    if let Some(dir) = cache_dir {
         return dir;
     }
     // SAFETY: `getuid()` is documented to always succeed and never
@@ -80,4 +88,114 @@ fn fallback_user_dir() -> PathBuf {
         );
     }
     dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Env-var manipulation is process-global, so the four cases
+    /// must run serially. A single test function with an internal
+    /// mutex guard is simpler than pulling in `serial_test` and
+    /// keeps every assertion in one self-contained scope.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<R>(history_overrides: &[(&str, Option<&str>)], body: impl FnOnce() -> R) -> R {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        // Snapshot the vars we touch so we can restore them.
+        let mut snapshot: Vec<(&str, Option<String>)> = Vec::new();
+        for (key, _) in history_overrides {
+            snapshot.push((key, std::env::var(key).ok()));
+        }
+        // Apply overrides.
+        for (key, value) in history_overrides {
+            // SAFETY: env mutation is unsafe in Rust 2024; the
+            // ENV_LOCK Mutex serializes our four test cases so no
+            // other thread is racing. Other tests in the crate
+            // don't touch these vars.
+            unsafe {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        let result = body();
+        // Restore.
+        for (key, original) in snapshot {
+            unsafe {
+                match original {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        result
+    }
+
+    #[test]
+    fn path_helpers_use_xdg_dirs_when_available_and_per_user_fallback_otherwise() {
+        let tmpdir = std::env::temp_dir().join(format!("nwg-paths-test-{}", std::process::id()));
+        std::fs::create_dir_all(&tmpdir).expect("setup tmpdir");
+        let runtime = tmpdir.join("runtime");
+        let cache = tmpdir.join("cache");
+        std::fs::create_dir_all(&runtime).expect("setup runtime");
+        std::fs::create_dir_all(&cache).expect("setup cache");
+
+        // Case 1: XDG_RUNTIME_DIR set → status_path uses it.
+        let actual = with_env(
+            &[("XDG_RUNTIME_DIR", Some(runtime.to_str().unwrap()))],
+            status_path,
+        );
+        assert_eq!(actual, runtime.join("mac-notifications-status.json"));
+
+        // Case 2: XDG_CACHE_HOME set → history_path uses it.
+        // (cache_dir() reads XDG_CACHE_HOME first.)
+        let actual = with_env(
+            &[("XDG_CACHE_HOME", Some(cache.to_str().unwrap()))],
+            history_path,
+        );
+        assert_eq!(actual, cache.join("mac-notifications-history.json"));
+
+        // Case 3: XDG_RUNTIME_DIR unset, XDG_CACHE_HOME set →
+        // status_path falls back through cache_dir.
+        let actual = with_env(
+            &[
+                ("XDG_RUNTIME_DIR", None),
+                ("XDG_CACHE_HOME", Some(cache.to_str().unwrap())),
+            ],
+            status_path,
+        );
+        assert_eq!(actual, cache.join("mac-notifications-status.json"));
+
+        // Case 4: cache_dir resolves to None (truly degraded — no
+        // $HOME, no $XDG_CACHE_HOME, no /etc/passwd entry) → per-UID
+        // /tmp sandbox via fallback_user_dir_from(None). We can't
+        // induce that None reliably with env-var manipulation
+        // (dirs::cache_dir falls back through /etc/passwd via
+        // getpwuid_r, so unsetting HOME doesn't suffice), so test
+        // the parameterized inner helper directly.
+        // SAFETY: getuid() is always-succeed POSIX FFI.
+        let uid = unsafe { libc::getuid() };
+        let actual = fallback_user_dir_from(None);
+        let expected = PathBuf::from("/tmp").join(format!("nwg-notifications-{uid}"));
+        assert_eq!(actual, expected);
+
+        // Sanity: the fallback dir was created with mode 0700.
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&actual)
+            .expect("fallback dir created")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "fallback dir must be mode 0700 to bound cross-user reads, got {:o}",
+            mode
+        );
+
+        // Cleanup.
+        let _ = std::fs::remove_dir_all(&tmpdir);
+    }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -110,13 +110,52 @@ fn fallback_user_dir_from(cache_dir: Option<PathBuf>) -> PathBuf {
         );
         return pid_suffixed;
     }
+    // Both deterministic paths failed safety checks. Try randomized
+    // names — a per-attempt nanos suffix is much harder for an
+    // attacker to pre-create as a trap than the predictable per-UID
+    // / per-PID names. Returning the unvalidated `preferred` here
+    // would let later writes follow whatever attacker-controlled
+    // path occupied that name.
+    let mut last_attempted = pid_suffixed.clone();
+    for attempt in 0..RANDOMIZED_FALLBACK_ATTEMPTS {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let randomized =
+            PathBuf::from("/tmp").join(format!("nwg-notifications-{uid}-r{attempt}-{nanos:x}"));
+        last_attempted = randomized.clone();
+        if try_create_or_validate(&randomized, uid) {
+            log::warn!(
+                "Falling back to randomized dir {} after both per-UID ({}) and per-PID ({}) \
+                 variants failed safety checks; persisted history will not survive daemon restarts.",
+                randomized.display(),
+                preferred.display(),
+                pid_suffixed.display()
+            );
+            return randomized;
+        }
+    }
+    // All retries exhausted. Return the *last* randomized path
+    // we tried (rather than `preferred`) so subsequent file writes
+    // hit a path that try_create_or_validate already rejected and
+    // fail loudly, rather than silently following a trap symlink
+    // or foreign-owned dir at the predictable per-UID name.
     log::error!(
-        "Both {} and {} failed safety checks; subsequent file writes will likely fail.",
-        preferred.display(),
-        pid_suffixed.display()
+        "All {} randomized fallback dirs failed safety checks (last tried: {}). \
+         Subsequent file writes will fail; the daemon's /tmp environment is unsafe.",
+        RANDOMIZED_FALLBACK_ATTEMPTS,
+        last_attempted.display()
     );
-    preferred
+    last_attempted
 }
+
+/// How many randomized names to try when the deterministic per-UID
+/// and per-PID fallback paths both fail safety checks. 16 is
+/// generous — any single attempt has astronomically low collision
+/// probability with a nanos-based suffix, so 16 covers even an
+/// attacker actively racing to claim names.
+const RANDOMIZED_FALLBACK_ATTEMPTS: u32 = 16;
 
 /// Tries to create `dir` with mode `0700` atomically (single
 /// `mkdir(2)` call, never `mkdir -p`-style pre-creation). If `dir`
@@ -179,37 +218,59 @@ mod tests {
     /// keeps every assertion in one self-contained scope.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// RAII guard: snapshots the env vars listed in the supplied
+    /// overrides on construction, applies the overrides, and restores
+    /// the snapshot on Drop. Drop runs even if the test body panics,
+    /// so a panicking assertion inside `with_env` doesn't leave the
+    /// process environment polluted for subsequent tests.
+    struct EnvRestore {
+        snapshot: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvRestore {
+        fn apply(overrides: &[(&str, Option<&str>)]) -> Self {
+            let mut snapshot: Vec<(String, Option<String>)> = Vec::new();
+            for (key, _) in overrides {
+                snapshot.push(((*key).to_string(), std::env::var(*key).ok()));
+            }
+            for (key, value) in overrides {
+                // SAFETY: env mutation is unsafe in Rust 2024; the
+                // ENV_LOCK Mutex (held by `with_env`'s caller)
+                // serializes our test cases so no other thread is
+                // racing. Other tests in the crate don't touch
+                // these vars.
+                unsafe {
+                    match value {
+                        Some(v) => std::env::set_var(key, v),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+            EnvRestore { snapshot }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (key, original) in self.snapshot.drain(..) {
+                // SAFETY: same justification as `apply` — ENV_LOCK
+                // serializes us with any other thread that touches
+                // these vars.
+                unsafe {
+                    match original {
+                        Some(v) => std::env::set_var(&key, v),
+                        None => std::env::remove_var(&key),
+                    }
+                }
+            }
+        }
+    }
+
     fn with_env<R>(history_overrides: &[(&str, Option<&str>)], body: impl FnOnce() -> R) -> R {
         let _guard = ENV_LOCK.lock().expect("env lock poisoned");
-        // Snapshot the vars we touch so we can restore them.
-        let mut snapshot: Vec<(&str, Option<String>)> = Vec::new();
-        for (key, _) in history_overrides {
-            snapshot.push((key, std::env::var(key).ok()));
-        }
-        // Apply overrides.
-        for (key, value) in history_overrides {
-            // SAFETY: env mutation is unsafe in Rust 2024; the
-            // ENV_LOCK Mutex serializes our four test cases so no
-            // other thread is racing. Other tests in the crate
-            // don't touch these vars.
-            unsafe {
-                match value {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        let result = body();
-        // Restore.
-        for (key, original) in snapshot {
-            unsafe {
-                match original {
-                    Some(v) => std::env::set_var(key, v),
-                    None => std::env::remove_var(key),
-                }
-            }
-        }
-        result
+        let _restore = EnvRestore::apply(history_overrides);
+        body()
+        // _restore drops here (or on panic unwind), restoring env.
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -33,10 +33,17 @@ pub(crate) fn history_path() -> PathBuf {
 /// Returns the path to the waybar status JSON file.
 /// Prefers `$XDG_RUNTIME_DIR`; falls back to `cache_dir()` and
 /// finally to a per-UID sandbox under `/tmp` if neither resolves.
+///
+/// An empty `XDG_RUNTIME_DIR` is treated as unset — `PathBuf::from("")`
+/// would otherwise give a relative path that resolves against the
+/// process's CWD (whatever `gtk4::Application::run` happened to set
+/// it to), which is never what we want for a runtime artifact.
 pub(crate) fn status_path() -> PathBuf {
     std::env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|_| fallback_user_dir())
+        .unwrap_or_else(fallback_user_dir)
         .join("mac-notifications-status.json")
 }
 
@@ -71,23 +78,80 @@ fn fallback_user_dir_from(cache_dir: Option<PathBuf>) -> PathBuf {
     // SAFETY: `getuid()` is documented to always succeed and never
     // return an error per POSIX. The `unsafe` is purely the FFI tag.
     let uid = unsafe { libc::getuid() };
-    let dir = PathBuf::from("/tmp").join(format!("nwg-notifications-{uid}"));
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        log::error!(
-            "Failed to create per-user fallback dir {}: {}",
-            dir.display(),
-            e
-        );
+    let preferred = PathBuf::from("/tmp").join(format!("nwg-notifications-{uid}"));
+    if try_create_or_validate(&preferred, uid) {
+        return preferred;
     }
-    use std::os::unix::fs::PermissionsExt;
-    if let Err(e) = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)) {
+    // The preferred per-UID path failed safety checks (foreign owner,
+    // symlink, regular file, or wrong mode that we couldn't fix).
+    // Fall through to a per-PID variant to avoid following an
+    // attacker-controlled path. Persistence across daemon restarts
+    // is sacrificed in this branch — but this whole function only
+    // runs in the truly degraded "no XDG dirs at all" environment,
+    // where losing history-file persistence is the better trade.
+    let pid_suffixed =
+        PathBuf::from("/tmp").join(format!("nwg-notifications-{uid}-{}", std::process::id()));
+    if try_create_or_validate(&pid_suffixed, uid) {
         log::warn!(
-            "Failed to set 0700 perms on fallback dir {}: {}",
-            dir.display(),
-            e
+            "Falling back to per-process dir {} because {} failed safety checks; \
+             persisted history will not survive daemon restarts in this configuration.",
+            pid_suffixed.display(),
+            preferred.display()
         );
+        return pid_suffixed;
     }
-    dir
+    log::error!(
+        "Both {} and {} failed safety checks; subsequent file writes will likely fail.",
+        preferred.display(),
+        pid_suffixed.display()
+    );
+    preferred
+}
+
+/// Tries to create `dir` with mode `0700` atomically (single
+/// `mkdir(2)` call, never `mkdir -p`-style pre-creation). If `dir`
+/// already exists, validates that it's a real directory owned by
+/// `uid` with mode `0700` — refuses (returns false) if any check
+/// fails. Returns true on a successful create or a successful
+/// validate of a pre-existing dir.
+///
+/// Refusing on validation failure is what bounds the symlink-clobber
+/// and foreign-owned-dir attacks: if `/tmp/nwg-notifications-<uid>`
+/// already exists as a symlink to `/etc/`, or as a directory owned
+/// by another user, we won't return its path for subsequent file
+/// writes. The caller falls through to a per-PID alternative or
+/// logs an error.
+fn try_create_or_validate(dir: &std::path::Path, uid: libc::uid_t) -> bool {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+    match std::fs::DirBuilder::new().mode(0o700).create(dir) {
+        Ok(()) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            match std::fs::symlink_metadata(dir) {
+                Ok(meta) => {
+                    let is_dir = meta.file_type().is_dir();
+                    let owned = meta.uid() == uid;
+                    let mode = meta.permissions().mode() & 0o777;
+                    if is_dir && owned && mode == 0o700 {
+                        return true;
+                    }
+                    log::error!(
+                        "Fallback dir {} fails safety checks (is_dir={is_dir}, \
+                         owned_by_us={owned}, mode={mode:o} expected 0700). Refusing to use.",
+                        dir.display()
+                    );
+                    false
+                }
+                Err(e) => {
+                    log::error!("Failed to stat fallback dir {}: {}", dir.display(), e);
+                    false
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("Failed to create fallback dir {}: {}", dir.display(), e);
+            false
+        }
+    }
 }
 
 #[cfg(test)]
@@ -193,6 +257,29 @@ mod tests {
             mode, 0o700,
             "fallback dir must be mode 0700 to bound cross-user reads, got {:o}",
             mode
+        );
+
+        // Cleanup.
+        let _ = std::fs::remove_dir_all(&tmpdir);
+    }
+
+    #[test]
+    fn try_create_or_validate_refuses_when_path_is_a_regular_file() {
+        // Pre-create the path as a regular file, then ask
+        // try_create_or_validate to handle it. It should refuse
+        // (return false) rather than treat the file as a directory
+        // — that's the symlink-clobber-class defense at work.
+        let tmpdir =
+            std::env::temp_dir().join(format!("nwg-paths-safety-test-{}", std::process::id()));
+        std::fs::create_dir_all(&tmpdir).expect("setup tmpdir");
+        let trap = tmpdir.join("trap-as-file");
+        std::fs::write(&trap, b"i am a regular file, not a directory").expect("setup trap");
+
+        // SAFETY: getuid() is always-succeed POSIX FFI.
+        let uid = unsafe { libc::getuid() };
+        assert!(
+            !try_create_or_validate(&trap, uid),
+            "try_create_or_validate must refuse a path that exists as a non-directory"
         );
 
         // Cleanup.

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -4,14 +4,7 @@
 //! and corrupt files by returning an empty history.
 
 use crate::notification::Notification;
-use std::path::{Path, PathBuf};
-
-/// Returns the path to the notification history file.
-pub(crate) fn history_path() -> PathBuf {
-    nwg_common::config::paths::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("mac-notifications-history.json")
-}
+use std::path::Path;
 
 /// Loads notification history from disk.
 pub(crate) fn load_history(path: &Path) -> Vec<Notification> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -117,6 +117,22 @@ impl NotificationState {
         self.active_popups.clear();
     }
 
+    /// Sets DND mode and (optionally) the timed-DND expiry, then
+    /// logs the transition. The single writer for the `dnd` and
+    /// `dnd_expires` fields — every UI / signal / timer call site
+    /// routes through this so the two fields can never drift.
+    ///
+    /// Pass `expires = None` for a permanent toggle (the panel
+    /// header button, the signal handler, the menu's "until I turn
+    /// it off" entry, and the timer-fire that clears expired DND).
+    /// Pass `expires = Some(deadline)` only for the timed-DND menu
+    /// buttons that arm a `glib::timeout_add_local_once`.
+    pub(crate) fn set_dnd(&mut self, enabled: bool, expires: Option<std::time::SystemTime>) {
+        self.dnd = enabled;
+        self.dnd_expires = expires;
+        log::info!("DND {}", if enabled { "enabled" } else { "disabled" });
+    }
+
     /// Marks a notification as read.
     pub(crate) fn mark_read(&mut self, id: u32) {
         if let Some(notif) = self.history.iter_mut().find(|n| n.id == id) {
@@ -250,10 +266,39 @@ mod tests {
     #[test]
     fn dnd_suppresses_normal_popups() {
         let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
-        state.dnd = true;
+        state.set_dnd(true, None);
         assert!(!state.should_show_popup(Urgency::Normal));
         assert!(!state.should_show_popup(Urgency::Low));
         assert!(state.should_show_popup(Urgency::Critical));
+    }
+
+    #[test]
+    fn set_dnd_clears_stale_expiry_when_toggling_off() {
+        // Bug fix from #37: before the set_dnd helper landed, the
+        // signal handler in listeners.rs and the panel-header button
+        // in ui/panel.rs both flipped state.dnd directly without
+        // touching dnd_expires. So a user who armed timed DND from
+        // the menu (sets dnd=true + Some(expiry)) and then toggled
+        // DND off via the waybar bell signal would end up with
+        // dnd=false but dnd_expires=Some(stale). The set_dnd helper
+        // makes (enabled, expires) a single atomic write — the
+        // signal-handler path passes None, which clears the expiry.
+
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
+
+        // Arm timed DND (mirrors the dnd_menu timed-DND button path).
+        let expiry = SystemTime::now() + std::time::Duration::from_secs(3600);
+        state.set_dnd(true, Some(expiry));
+        assert!(state.dnd);
+        assert_eq!(state.dnd_expires, Some(expiry));
+
+        // Toggle off via signal (mirrors the listeners.rs ToggleDnd path).
+        state.set_dnd(false, None);
+        assert!(!state.dnd);
+        assert_eq!(
+            state.dnd_expires, None,
+            "toggling DND off via signal must clear stale dnd_expires"
+        );
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -25,10 +25,15 @@ pub(crate) struct NotificationState {
     pub(crate) history: Vec<Notification>,
     /// Next ID to assign (starts at 1).
     next_id: u32,
-    /// Do Not Disturb mode.
-    pub(crate) dnd: bool,
-    /// When timed DND expires (None = permanent or off).
-    pub(crate) dnd_expires: Option<std::time::SystemTime>,
+    /// Do Not Disturb mode. Private — readers go through
+    /// `is_dnd_enabled`, writers through `set_dnd`. Privatized in
+    /// the #37 cleanup so the `(dnd, dnd_expires)` invariant can't
+    /// drift via stray direct field writes.
+    dnd: bool,
+    /// When timed DND expires (None = permanent or off). Private
+    /// for the same reason as `dnd`; readers go through the
+    /// `dnd_expires` accessor, writers through `set_dnd`.
+    dnd_expires: Option<std::time::SystemTime>,
     /// App directories for icon resolution.
     pub(crate) app_dirs: Vec<PathBuf>,
     /// IDs of notifications currently showing as popups.
@@ -115,6 +120,18 @@ impl NotificationState {
     pub(crate) fn dismiss_all(&mut self) {
         self.history.clear();
         self.active_popups.clear();
+    }
+
+    /// Returns whether DND is currently active.
+    pub(crate) fn is_dnd_enabled(&self) -> bool {
+        self.dnd
+    }
+
+    /// Returns the current timed-DND expiry, if any. `None` means
+    /// either permanent DND (toggled on without an expiry) or DND
+    /// is off entirely.
+    pub(crate) fn dnd_expires(&self) -> Option<std::time::SystemTime> {
+        self.dnd_expires
     }
 
     /// Sets DND mode and (optionally) the timed-DND expiry, then

--- a/src/state.rs
+++ b/src/state.rs
@@ -146,7 +146,13 @@ impl NotificationState {
     /// buttons that arm a `glib::timeout_add_local_once`.
     pub(crate) fn set_dnd(&mut self, enabled: bool, expires: Option<std::time::SystemTime>) {
         self.dnd = enabled;
-        self.dnd_expires = expires;
+        // Normalize: an "off" DND with a non-None expiry is a
+        // degenerate state that the rest of the code doesn't handle
+        // (the timer-fire token check would still fire even though
+        // DND is already off). Force expiry to None when disabling
+        // so a future caller that gets the API wrong can't reintroduce
+        // the (dnd, dnd_expires) drift this helper exists to prevent.
+        self.dnd_expires = if enabled { expires } else { None };
         log::info!("DND {}", if enabled { "enabled" } else { "disabled" });
     }
 
@@ -315,6 +321,24 @@ mod tests {
         assert_eq!(
             state.dnd_expires, None,
             "toggling DND off via signal must clear stale dnd_expires"
+        );
+    }
+
+    #[test]
+    fn set_dnd_off_normalizes_away_caller_supplied_expiry() {
+        // Defensive normalization: even if a future caller passes
+        // set_dnd(false, Some(...)) by mistake, the helper must
+        // discard the expiry — DND being off and dnd_expires being
+        // populated is a degenerate state that the timer-fire token
+        // check + dnd_menu's "show remaining time" UI weren't built
+        // to handle.
+        let mut state = NotificationState::new(vec![], test_config_with_max_history(100));
+        let bogus = SystemTime::now() + std::time::Duration::from_secs(3600);
+        state.set_dnd(false, Some(bogus));
+        assert!(!state.dnd, "set_dnd(false, _) must leave dnd disabled");
+        assert_eq!(
+            state.dnd_expires, None,
+            "set_dnd(false, _) must clear any caller-supplied expiry"
         );
     }
 

--- a/src/ui/dnd_menu.rs
+++ b/src/ui/dnd_menu.rs
@@ -133,9 +133,7 @@ impl DndMenu {
         let backdrops_toggle = self.backdrops.clone();
         toggle_btn.connect_clicked(move |_| {
             let new_dnd = !state_toggle.borrow().dnd;
-            state_toggle.borrow_mut().dnd = new_dnd;
-            state_toggle.borrow_mut().dnd_expires = None;
-            log::info!("DND {}", if new_dnd { "enabled" } else { "disabled" });
+            state_toggle.borrow_mut().set_dnd(new_dnd, None);
             on_change_toggle();
             win_toggle.set_visible(false);
             for b in &backdrops_toggle {
@@ -216,9 +214,8 @@ fn build_timed_dnd_button(
     let win_btn = win.clone();
     let backdrops_btn: Vec<_> = backdrops.to_vec();
     btn.connect_clicked(move |_| {
-        state_btn.borrow_mut().dnd = true;
         let expiry = std::time::SystemTime::now() + std::time::Duration::from_secs(minutes * 60);
-        state_btn.borrow_mut().dnd_expires = Some(expiry);
+        state_btn.borrow_mut().set_dnd(true, Some(expiry));
         log::info!("DND enabled for {} minutes", minutes);
 
         // Capture the expiry we just stored. If the user clicks a
@@ -235,8 +232,7 @@ fn build_timed_dnd_button(
             move || {
                 let current = state_timer.borrow().dnd_expires;
                 if current == Some(captured_expiry) {
-                    state_timer.borrow_mut().dnd = false;
-                    state_timer.borrow_mut().dnd_expires = None;
+                    state_timer.borrow_mut().set_dnd(false, None);
                     log::info!("Timed DND expired");
                     on_change_timer();
                 }

--- a/src/ui/dnd_menu.rs
+++ b/src/ui/dnd_menu.rs
@@ -117,7 +117,7 @@ impl DndMenu {
         vbox.set_margin_bottom(8);
 
         // Toggle button — label reflects current state
-        let is_dnd = self.state.borrow().dnd;
+        let is_dnd = self.state.borrow().is_dnd_enabled();
         let toggle_label = if is_dnd {
             "Turn off Do Not Disturb"
         } else {
@@ -132,7 +132,7 @@ impl DndMenu {
         let win_toggle = self.win.clone();
         let backdrops_toggle = self.backdrops.clone();
         toggle_btn.connect_clicked(move |_| {
-            let new_dnd = !state_toggle.borrow().dnd;
+            let new_dnd = !state_toggle.borrow().is_dnd_enabled();
             state_toggle.borrow_mut().set_dnd(new_dnd, None);
             on_change_toggle();
             win_toggle.set_visible(false);
@@ -144,7 +144,7 @@ impl DndMenu {
 
         if is_dnd {
             // Show remaining time if timed DND is active
-            if let Some(expiry) = self.state.borrow().dnd_expires
+            if let Some(expiry) = self.state.borrow().dnd_expires()
                 && let Ok(remaining) = expiry.duration_since(std::time::SystemTime::now())
             {
                 let mins = remaining.as_secs() / 60;
@@ -230,7 +230,7 @@ fn build_timed_dnd_button(
         gtk4::glib::timeout_add_local_once(
             std::time::Duration::from_secs(minutes * 60),
             move || {
-                let current = state_timer.borrow().dnd_expires;
+                let current = state_timer.borrow().dnd_expires();
                 if current == Some(captured_expiry) {
                     state_timer.borrow_mut().set_dnd(false, None);
                     log::info!("Timed DND expired");

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -253,7 +253,7 @@ fn build_header(
     let state_dnd = Rc::clone(state);
     let on_change_dnd = Rc::clone(on_state_change);
     dnd_btn.connect_clicked(move |btn| {
-        let new_dnd = !state_dnd.borrow().dnd;
+        let new_dnd = !state_dnd.borrow().is_dnd_enabled();
         state_dnd.borrow_mut().set_dnd(new_dnd, None);
         let icon = if new_dnd {
             "notifications-disabled-symbolic"

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -254,14 +254,13 @@ fn build_header(
     let on_change_dnd = Rc::clone(on_state_change);
     dnd_btn.connect_clicked(move |btn| {
         let new_dnd = !state_dnd.borrow().dnd;
-        state_dnd.borrow_mut().dnd = new_dnd;
+        state_dnd.borrow_mut().set_dnd(new_dnd, None);
         let icon = if new_dnd {
             "notifications-disabled-symbolic"
         } else {
             "preferences-system-notifications-symbolic"
         };
         btn.set_icon_name(icon);
-        log::info!("DND {}", if new_dnd { "enabled" } else { "disabled" });
         on_change_dnd();
     });
     header.append(&dnd_btn);

--- a/src/waybar.rs
+++ b/src/waybar.rs
@@ -12,7 +12,6 @@
 //! [Nerd Fonts]: https://www.nerdfonts.com/
 
 use serde::Serialize;
-use std::path::PathBuf;
 
 /// Offset above `SIGRTMIN` that waybar's notification module listens on.
 /// Kept as a single named constant so the implementation and its test
@@ -54,14 +53,6 @@ struct WaybarStatus {
     count: usize,
 }
 
-/// Returns the path to the waybar status file.
-fn status_path() -> PathBuf {
-    std::env::var("XDG_RUNTIME_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/tmp"))
-        .join("mac-notifications-status.json")
-}
-
 /// Pure helper: builds the waybar status payload for the current
 /// daemon state. Split out from `update_status` so the four-way
 /// shape can be tested without going through disk I/O.
@@ -100,7 +91,7 @@ fn build_status(unread: usize, dnd: bool) -> WaybarStatus {
 pub(crate) fn update_status(unread: usize, dnd: bool) {
     let status = build_status(unread, dnd);
 
-    let path = status_path();
+    let path = crate::paths::status_path();
     match serde_json::to_string(&status) {
         Ok(json) => {
             if let Err(e) = std::fs::write(&path, json) {


### PR DESCRIPTION
## Summary

Bundles two internal-state refactors from epic #29 into one PR:

- **#39** — Lifted `history_path` (was in `src/persistence.rs`) and `status_path` (was in `src/waybar.rs`) into a new `src/paths.rs` module. The two filename conventions now sit together; #34's eventual `mac-notifications-*` → `nwg-notifications-*` rename is a single-file change. `persistence.rs` and `waybar.rs` shrink slightly; the only call-site change in `main.rs` is `persistence::history_path()` → `paths::history_path()`. Trimmed two unused `PathBuf` imports while there.
- **#37** — Added `NotificationState::set_dnd(enabled, expires)` as the single writer for the `dnd` and `dnd_expires` fields. Routed all 5 write sites through it (`listeners.rs::poll_signals` ToggleDnd arm, `ui/panel.rs` panel-header DND button, and 3 sites in `ui/dnd_menu.rs`: toggle button, timed-DND button, timer-fire callback). Logging moves into the helper. **Latent bug fix:** the signal-handler and panel-header paths used to leave `dnd_expires` stale when toggling off — now they pass `None` and clear it atomically. The startup initialization in `main.rs` keeps its direct field write (no `on_state_change` to fire, runs before the daemon is wired).

One commit per issue. No CHANGELOG entry — the bug fix is a latent issue that's never been reported (mostly harmless because the timer-fire token check from #31 makes the stale expiry a no-op).

## Test plan

- [x] `make lint` clean locally (fmt + clippy + test + deny + audit). Test count: 87 → 88 (+1 for the #37 bug-fix test `set_dnd_clears_stale_expiry_when_toggling_off`).
- [x] Manual smoke test against the live compositor (installed via `make upgrade PREFIX=\$HOME/.local BINDIR=\$HOME/.cargo/bin`):
  - [x] `notify-send` produces a popup; persisted history still round-trips.
  - [x] Arm timed DND from the menu, toggle off via `kill -RTMIN+5 \$(pidof nwg-notifications)`, re-enable from menu — no stale timer races to clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toggling Do Not Disturb off now reliably clears stale expiry times so DND no longer lingers.

* **Chores**
  * Centralized DND state changes so signals, UI, timers, and status updates route through a single setter for consistent behavior.
  * Centralized runtime path helpers for predictable status/history file locations and robust /tmp fallback handling.

* **Tests**
  * Added unit tests for DND expiry clearing and runtime-path selection.

* **Documentation**
  * Added an implementation plan documenting the coordinated refactor and checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->