### PR TITLE
chore(deps): bump nwg-common 0.4 → 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] — Unreleased
 
+### Changed
+
+- Bumped `nwg-common` dependency from `0.4` to `0.5`. No public-API
+  impact for `nwg-notifications`: the only addition in `nwg-common 0.5.0`
+  is the rebindable CSS watcher (`watch_css_rebindable` /
+  `CssWatchHandle` / `CssRebindError`) used by `nwg-dock`'s newly-
+  configurable `css-file` path; we still use the non-rebindable
+  `watch_css` for our embedded-default CSS hot-reload, which is
+  unchanged. Pulled in to stay current with the nwg-* family.
+
 ## [0.4.0] — 2026-05-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "nwg-common"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406ced31ecc8842d92eb2c828dc9ad69ba143ebbdbeae702041ec0da02026977"
+checksum = "37643d5e67cc883e6f973651366b758d574bfdfac030c4c233606bf15415f294"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "nwg-notifications"
 path = "src/main.rs"
 
 [dependencies]
-# Shared library (library + binaries all on the 0.4.x line)
-nwg-common = "0.4"
+# Shared library (library + binaries all on the 0.5.x line)
+nwg-common = "0.5"
 
 # GTK4 + Wayland layer shell. `gtk4::gio` provides the D-Bus server
 # plumbing (bus_own_name, BusType::Session, DBusConnection); no


### PR DESCRIPTION
## Summary

Pulls in [`nwg-common 0.5.0`](https://crates.io/crates/nwg-common/0.5.0). The 0.5 release is purely additive — adds \`watch_css_rebindable\` + \`CssWatchHandle\` + \`CssRebindError\` for \`nwg-dock\`'s newly-configurable \`css-file\` path that needs to atomically rebind the inotify watcher when the user changes the path at runtime. \`nwg-notifications\` uses the non-rebindable \`watch_css\` for embedded-default CSS hot-reload, which is unchanged.

No code changes needed locally — caret-bump from \`"0.4"\` to \`"0.5"\` in \`Cargo.toml\` + regenerated \`Cargo.lock\`. CHANGELOG \`[0.4.1] — Unreleased\` gets a Changed bullet noting the bump.

## Test plan

- [x] \`make lint\` clean locally (fmt + clippy + test + deny + audit). Test count unchanged at 93.
- [x] \`cargo build --release\` clean against nwg-common 0.5.
- [x] Manual smoke test against the live compositor (installed via \`make upgrade PREFIX=\$HOME/.local BINDIR=\$HOME/.cargo/bin\`):
  - [x] \`notify-send\` produces a popup.
  - [x] Panel opens (verifies CSS hot-reload path still wires up).
  - [x] DND menu opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shared dependency to the latest version with no impact to the public API.

* **Documentation**
  * Updated changelog to document dependency version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->