### PR TITLE
feat: auto-activate daemon on org.nwg.Notifications calls (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] — Unreleased
 
+### Added
+
+- Second D-Bus service file `org.nwg.Notifications.service` so the
+  daemon auto-activates when an app calls **either**
+  `org.freedesktop.Notifications` (the standard notify path) or
+  `org.nwg.Notifications` (the project-private count IPC that
+  nwg-panel uses for its bell badge). Closes [#65](https://github.com/jasonherald/nwg-notifications/issues/65)
+  / [#63](https://github.com/jasonherald/nwg-notifications/issues/63).
+  Before this fix, nwg-panel users on cold boot would see
+  `NameHasNoOwner` errors until a notifying app (browser, mail
+  client, etc.) fired the first notification and triggered the
+  freedesktop-name auto-activation. `make install-dbus` now installs
+  both service files; `make uninstall` removes both. Stand-alone
+  `cargo install` users need to create the second file manually —
+  see the README's `D-Bus service` section for the template.
+
 ### Changed
 
 - Bumped `nwg-common` dependency from `0.4` to `0.5`. No public-API

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ BIN_NAME := nwg-notifications
 # D-Bus user-service location — always user-scope regardless of PREFIX.
 # XDG_DATA_HOME defaults to ~/.local/share.
 DBUS_USER_DIR := $(HOME)/.local/share/dbus-1/services
-DBUS_SERVICE_NAME := org.freedesktop.Notifications.service
-DBUS_SERVICE_TEMPLATE := data/$(DBUS_SERVICE_NAME).in
+# Two service files ship: the standard freedesktop notification interface
+# (auto-activated when an app calls `Notify`), and the project-private
+# `org.nwg.Notifications` count IPC (auto-activated when nwg-panel queries
+# the count badge on cold boot — see #65 for context).
+DBUS_SERVICE_NAMES := org.freedesktop.Notifications.service org.nwg.Notifications.service
 
 SONAR_SCANNER ?= /opt/sonar-scanner/bin/sonar-scanner
 SONAR_HOST_URL ?= https://sonar.aaru.network
@@ -141,18 +144,27 @@ install-dbus:
 			echo "  (getent passwd returned nothing — is $$SUDO_USER a real user on this system?)"; \
 			exit 1; \
 		}; \
-		echo "sudo detected — installing D-Bus service file for user $$SUDO_USER (home: $$TARGET_HOME)"; \
+		echo "sudo detected — installing D-Bus service files for user $$SUDO_USER (home: $$TARGET_HOME)"; \
 	fi; \
 	TARGET_DIR="$$TARGET_HOME/.local/share/dbus-1/services"; \
-	TARGET_FILE="$$TARGET_DIR/$(DBUS_SERVICE_NAME)"; \
 	BIN_PATH="$(BINDIR)/$(BIN_NAME)"; \
-	echo "Installing D-Bus service file to $$TARGET_FILE"; \
-	echo "  (D-Bus Exec path → $$BIN_PATH)"; \
 	mkdir -p "$$TARGET_DIR" || exit 1; \
-	sed "s|@BIN_PATH@|$$BIN_PATH|g" "$(DBUS_SERVICE_TEMPLATE)" > "$$TARGET_FILE" || exit 1; \
+	for SERVICE_NAME in $(DBUS_SERVICE_NAMES); do \
+		TEMPLATE="data/$$SERVICE_NAME.in"; \
+		TARGET_FILE="$$TARGET_DIR/$$SERVICE_NAME"; \
+		echo "Installing D-Bus service file to $$TARGET_FILE"; \
+		echo "  (D-Bus Exec path → $$BIN_PATH)"; \
+		sed "s|@BIN_PATH@|$$BIN_PATH|g" "$$TEMPLATE" > "$$TARGET_FILE" || exit 1; \
+		if [ -n "$$SUDO_USER" ] && [ "$$(id -u)" -eq 0 ]; then \
+			chown "$$SUDO_USER:" "$$TARGET_FILE" || { \
+				echo "ERROR: chown $$TARGET_FILE to $$SUDO_USER failed; D-Bus user-service would be unmanageable by the target user"; \
+				exit 1; \
+			}; \
+		fi; \
+	done; \
 	if [ -n "$$SUDO_USER" ] && [ "$$(id -u)" -eq 0 ]; then \
-		chown "$$SUDO_USER:" "$$TARGET_FILE" "$$TARGET_DIR" || { \
-			echo "ERROR: chown to $$SUDO_USER failed; D-Bus user-service would be unmanageable by the target user"; \
+		chown "$$SUDO_USER:" "$$TARGET_DIR" || { \
+			echo "ERROR: chown $$TARGET_DIR to $$SUDO_USER failed"; \
 			exit 1; \
 		}; \
 	fi
@@ -160,18 +172,20 @@ install-dbus:
 uninstall:
 	@echo "Removing binary"
 	rm -f "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
-	@echo "Removing D-Bus service file"
+	@echo "Removing D-Bus service files"
 	@TARGET_HOME="$$HOME"; \
 	if [ -n "$$SUDO_USER" ] && [ "$$(id -u)" -eq 0 ]; then \
 		TARGET_HOME="$$(getent passwd "$$SUDO_USER" | cut -d: -f6)"; \
 		test -n "$$TARGET_HOME" || { \
 			echo "ERROR: cannot resolve home directory for SUDO_USER=$$SUDO_USER"; \
-			echo "  (getent passwd returned nothing — D-Bus service file left behind;"; \
+			echo "  (getent passwd returned nothing — D-Bus service files left behind;"; \
 			echo "   remove manually from that user's ~/.local/share/dbus-1/services/)"; \
 			exit 1; \
 		}; \
 	fi; \
-	rm -f "$$TARGET_HOME/.local/share/dbus-1/services/$(DBUS_SERVICE_NAME)"
+	for SERVICE_NAME in $(DBUS_SERVICE_NAMES); do \
+		rm -f "$$TARGET_HOME/.local/share/dbus-1/services/$$SERVICE_NAME"; \
+	done
 	@echo "Uninstalled."
 
 # ─────────────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,11 @@ uninstall-dbus:
 		}; \
 	fi; \
 	for SERVICE_NAME in $(DBUS_SERVICE_NAMES); do \
-		rm -f "$$TARGET_HOME/.local/share/dbus-1/services/$$SERVICE_NAME"; \
+		TARGET_FILE="$$TARGET_HOME/.local/share/dbus-1/services/$$SERVICE_NAME"; \
+		rm -f "$$TARGET_FILE" || { \
+			echo "ERROR: failed to remove $$TARGET_FILE — refusing to continue with a stale D-Bus state"; \
+			exit 1; \
+		}; \
 	done
 
 uninstall: uninstall-dbus

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ SONAR_TRUSTSTORE_PASSWORD ?= changeit
 
 .PHONY: all build build-release test lint check-tools \
         lint-fmt lint-clippy lint-test lint-deny lint-audit \
-        install install-bin install-dbus uninstall \
+        install install-bin install-dbus uninstall uninstall-dbus \
         upgrade \
         sonar clean help
 
@@ -50,8 +50,9 @@ Targets:
   make lint            Full local check: fmt + clippy + test + deny + audit
   make install         Build release + install binary (system-scope) + install-dbus (user-scope)
   make install-bin     Install binary to $(DESTDIR)$(BINDIR)
-  make install-dbus    Install D-Bus service file to $(DBUS_USER_DIR) — ALWAYS user-scope (no sudo)
-  make uninstall       Remove installed binary (system) and D-Bus service file (user)
+  make install-dbus    Install D-Bus service files to $(DBUS_USER_DIR) — ALWAYS user-scope (no sudo)
+  make uninstall       Remove installed binary (system) and D-Bus service files (user)
+  make uninstall-dbus  Remove D-Bus service files only (user) — symmetric with install-dbus
   make upgrade         Resident-aware: capture running args, stop, rebuild, install, restart
   make sonar           Run SonarQube scan (requires sonar-scanner + .env)
   make clean           cargo clean
@@ -169,9 +170,10 @@ install-dbus:
 		}; \
 	fi
 
-uninstall:
-	@echo "Removing binary"
-	rm -f "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
+# uninstall-dbus mirrors install-dbus: removes every service file
+# install-dbus would lay down. Symmetric so packagers + scripts can
+# clean up D-Bus state without removing the binary (and vice versa).
+uninstall-dbus:
 	@echo "Removing D-Bus service files"
 	@TARGET_HOME="$$HOME"; \
 	if [ -n "$$SUDO_USER" ] && [ "$$(id -u)" -eq 0 ]; then \
@@ -186,6 +188,10 @@ uninstall:
 	for SERVICE_NAME in $(DBUS_SERVICE_NAMES); do \
 		rm -f "$$TARGET_HOME/.local/share/dbus-1/services/$$SERVICE_NAME"; \
 	done
+
+uninstall: uninstall-dbus
+	@echo "Removing binary"
+	rm -f "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
 	@echo "Uninstalled."
 
 # ─────────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ nwg-notifications --wm sway --persist
 
 ## D-Bus service
 
-`make install-dbus` installs this file into `~/.local/share/dbus-1/services/`. If you're cargo-installing, create it manually:
+`make install-dbus` installs **two** service files into `~/.local/share/dbus-1/services/`. If you're cargo-installing, create them manually:
 
 ```ini
 # ~/.local/share/dbus-1/services/org.freedesktop.Notifications.service
@@ -133,7 +133,14 @@ Name=org.freedesktop.Notifications
 Exec=/home/YOU/.cargo/bin/nwg-notifications --persist
 ```
 
-Once registered, the daemon auto-starts the first time any app calls `org.freedesktop.Notifications`.
+```ini
+# ~/.local/share/dbus-1/services/org.nwg.Notifications.service
+[D-BUS Service]
+Name=org.nwg.Notifications
+Exec=/home/YOU/.cargo/bin/nwg-notifications --persist
+```
+
+Once registered, the daemon auto-starts the first time any app calls **either** `org.freedesktop.Notifications` (the standard notify path that browsers, mail clients, etc. use) or `org.nwg.Notifications` (the project-private count IPC that nwg-panel uses for its bell-badge query). One daemon owns both names.
 
 ## Hyprland autostart
 
@@ -142,7 +149,7 @@ Once registered, the daemon auto-starts the first time any app calls `org.freede
 exec-once = uwsm-app -- nwg-notifications --persist
 ```
 
-Autostart isn't strictly required thanks to D-Bus auto-activation, but it makes the daemon ready before the first notification arrives (avoids a few-hundred-millisecond delay on your first toast).
+Autostart isn't strictly required thanks to D-Bus auto-activation on either name, but it makes the daemon ready before the first call — avoids a few-hundred-millisecond startup delay on your first toast (or your first nwg-panel count query on cold boot).
 
 ## Signal control
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Cargo-install users without a source clone should use the manual equivalent — 
 cargo install nwg-notifications
 ```
 
-This is the right path if you prefer the Rust toolchain workflow over `make install`. **Heads-up: this is a two-step install** — `cargo install` only places the binary at `~/.cargo/bin/nwg-notifications`, it doesn't create the D-Bus service file the daemon needs to be reachable. After running the command above, manually create the service file (see [D-Bus service](#d-bus-service) below; it's a ~5-line file pointing at the installed binary). Once the service file is in place, the daemon auto-activates the first time any app calls `org.freedesktop.Notifications`.
+This is the right path if you prefer the Rust toolchain workflow over `make install`. **Heads-up: this is a two-step install** — `cargo install` only places the binary at `~/.cargo/bin/nwg-notifications`, it doesn't create the **two** D-Bus service files the daemon needs to be reachable on either of its bus names. After running the command above, manually create both service files (see [D-Bus service](#d-bus-service) below; both are ~5-line files pointing at the installed binary). Once both service files are in place, the daemon auto-activates the first time any app calls **either** `org.freedesktop.Notifications` (the standard notify path) or `org.nwg.Notifications` (the count IPC nwg-panel uses). One daemon owns both names.
 
 For the all-in-one experience, use the [`make install`](#make-install--recommended-one-stop-binary--d-bus-service-file) path above.
 

--- a/data/org.nwg.Notifications.service.in
+++ b/data/org.nwg.Notifications.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.nwg.Notifications
+Exec=@BIN_PATH@ --persist


### PR DESCRIPTION
## Summary

Closes **#65**, addresses **#63** (Piotr Miller's cold-boot report).

We shipped a D-Bus service file for \`org.freedesktop.Notifications\` (the notify path that browsers, mail clients, etc. trigger) but **not** for \`org.nwg.Notifications\` (the project-private count IPC introduced in #9/#20 for nwg-panel + nwg-shell-config). On cold boot, before any app has fired a notification, nwg-panel's count-badge query returns \`NameHasNoOwner\` because nothing was triggering daemon activation on the count-IPC name.

This PR adds the missing service file so the daemon auto-activates on **either** name's first call. One daemon owns both.

### Changes

- **New** \`data/org.nwg.Notifications.service.in\` — mirrors the existing freedesktop one (same \`@BIN_PATH@\` substitution, same \`--persist\` flag baked into \`Exec=\`).
- **Makefile** — \`DBUS_SERVICE_NAME\` (singular) becomes \`DBUS_SERVICE_NAMES\` (plural list); \`install-dbus\` and \`uninstall\` loop over the list, so adding a third service file later is a one-variable edit.
- **README** — the "D-Bus service" section now documents both files; the "Hyprland autostart" section's auto-activation claim correctly covers both names.
- **CHANGELOG** — \`[0.4.1] — Unreleased\` gets an Added bullet.

## Test plan

- [x] \`make lint\` clean locally (fmt + clippy + test + deny + audit). Test count unchanged at 93.
- [x] **Live smoke test against this dev machine's session bus**:
  - [x] \`make install-dbus BINDIR=\$HOME/.cargo/bin\` lands both \`org.freedesktop.Notifications.service\` and \`org.nwg.Notifications.service\` in \`~/.local/share/dbus-1/services/\` with the correct \`Exec=\` paths.
  - [x] With no daemon running, \`dbus-send --session --dest=org.nwg.Notifications /org/nwg/Notifications org.nwg.Notifications.GetCount\` auto-spawns the daemon and returns \`uint32 0\`.
  - [x] With no daemon running, \`dbus-send --session --dest=org.freedesktop.Notifications /org/freedesktop/Notifications org.freedesktop.Notifications.GetCapabilities\` still auto-spawns (existing path unaffected).

## Cross-repo coordination note

nwg-panel can pair this fix with one of:
- (A) Drop \`gio::DBusCallFlags::NO_AUTO_START\` from its count query so the daemon auto-spawns on demand, **or**
- (B) Catch \`NameHasNoOwner\` and treat as 0 unread (Piotr's defensive workaround from #63).

Recommend (A) for the primary fix + (B) as belt-and-suspenders for transient daemon outages. Either is a nwg-panel-side change; tracking here only for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installs a second D-Bus service name so the notification daemon auto-activates for both notify and project-private count IPC, preventing startup name ownership errors on cold boot.

* **Chores**
  * Installer now handles multiple user-scope D-Bus service units and adds an uninstall target to remove all installed service files.

* **Documentation**
  * README and changelog updated to describe multi-service behavior and install instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->