### PR TITLE
fix(--update): auto-activate daemon instead of erroring with NameHasNoOwner (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses a wider 5s timeout to absorb the cold-spawn latency of GTK4
   init and D-Bus name registration. The freshly-spawned daemon
   loads `config.json`, accepts the `Set*`, and persists the field
-  back via the same atomic-write path as a live `Set*` — so the
-  end state is identical to "daemon was running, push, file
-  updated". `--count` still uses `NO_AUTO_START` (auto-spawning
+  back via the same atomic-write path as a live `Set*`, so the
+  persisted config outcome matches an update against an already-
+  running daemon. `--count` still uses `NO_AUTO_START` (auto-spawning
   a daemon just to return zero would be wrong).
 
 ## [0.4.0] — 2026-05-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `watch_css` for our embedded-default CSS hot-reload, which is
   unchanged. Pulled in to stay current with the nwg-* family.
 
+### Fixed
+
+- `nwg-notifications --update --<flag> <value>` now auto-activates the
+  daemon when none is running, instead of failing with
+  `org.freedesktop.DBus.Error.NameHasNoOwner` ([#67](https://github.com/jasonherald/nwg-notifications/issues/67)).
+  The setter path (`call_setter_sync`) drops `NO_AUTO_START` and
+  uses a wider 5s timeout to absorb the cold-spawn latency of GTK4
+  init and D-Bus name registration. The freshly-spawned daemon
+  loads `config.json`, accepts the `Set*`, and persists the field
+  back via the same atomic-write path as a live `Set*` — so the
+  end state is identical to "daemon was running, push, file
+  updated". `--count` still uses `NO_AUTO_START` (auto-spawning
+  a daemon just to return zero would be wrong).
+
 ## [0.4.0] — 2026-05-04
 
 ### Changed

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -626,6 +626,15 @@ pub(crate) fn unread_count_to_u32(unread: usize) -> u32 {
 /// the CLI responsive when something is genuinely broken.
 const QUERY_COUNT_TIMEOUT_MS: i32 = 2_000;
 
+/// Timeout for the six `--update` D-Bus pushes. Wider than
+/// `QUERY_COUNT_TIMEOUT_MS` because the setter path drops `NO_AUTO_START`
+/// (a write should auto-spawn the daemon if none is running). On a cold
+/// boot the auto-activation chain — D-Bus exec, GTK4 init, layer-shell
+/// and name registration, then method dispatch — can take a few hundred
+/// ms; 5s gives plenty of headroom while still failing fast on something
+/// genuinely broken.
+const SETTER_TIMEOUT_MS: i32 = 5_000;
+
 /// Queries the running daemon's `GetCount()` method over the session bus
 /// and returns the unread count. Uses `NO_AUTO_START` so it never spawns
 /// a daemon — if no daemon is running, this returns an error.
@@ -661,8 +670,14 @@ pub(crate) fn query_count_via_dbus() -> Result<u32, glib::Error> {
 }
 
 /// Generic D-Bus client helper used by all six `--update` push wrappers.
-/// Same NO_AUTO_START + QUERY_COUNT_TIMEOUT_MS semantics as
-/// `query_count_via_dbus`.
+/// Unlike `query_count_via_dbus`, this path *allows* auto-activation:
+/// `--update` is a write operation, so if no daemon is running the right
+/// thing is to spawn one via the `org.nwg.Notifications.service` file,
+/// queue the method call, and let it land on the freshly-spawned daemon.
+/// The fresh daemon loads `config.json`, accepts the `Set*`, and writes
+/// the field back — same end-state as if the daemon had been running
+/// when the push arrived. `SETTER_TIMEOUT_MS` (5s) absorbs the
+/// cold-spawn latency.
 fn call_setter_sync(method: &str, payload: glib::Variant) -> Result<(), glib::Error> {
     let connection = gio::bus_get_sync(gio::BusType::Session, gio::Cancellable::NONE)?;
     connection.call_sync(
@@ -672,8 +687,8 @@ fn call_setter_sync(method: &str, payload: glib::Variant) -> Result<(), glib::Er
         method,
         Some(&payload),
         None,
-        gio::DBusCallFlags::NO_AUTO_START,
-        QUERY_COUNT_TIMEOUT_MS,
+        gio::DBusCallFlags::NONE,
+        SETTER_TIMEOUT_MS,
         gio::Cancellable::NONE,
     )?;
     Ok(())
@@ -687,8 +702,9 @@ fn call_setter_sync(method: &str, payload: glib::Variant) -> Result<(), glib::Er
 ///
 /// Returns the underlying `glib::Error` when:
 /// - The session bus isn't reachable.
-/// - No daemon owns the `org.nwg.Notifications` name (the
-///   `NO_AUTO_START` flag means the call doesn't spawn one).
+/// - The daemon isn't running and D-Bus auto-activation can't recover
+///   (the `org.nwg.Notifications.service` file is missing, or its
+///   `Exec=` path doesn't resolve — see `make install-dbus`).
 /// - The daemon rejects the value with
 ///   `org.freedesktop.DBus.Error.InvalidArgs` (for example, an
 ///   unrecognised position string).
@@ -708,7 +724,9 @@ pub(crate) fn push_popup_position(value: &str) -> Result<(), glib::Error> {
 ///
 /// Returns the underlying `glib::Error` when:
 /// - The session bus isn't reachable.
-/// - No daemon owns the `org.nwg.Notifications` name.
+/// - The daemon isn't running and D-Bus auto-activation can't recover
+///   (the `org.nwg.Notifications.service` file is missing, or its
+///   `Exec=` path doesn't resolve — see `make install-dbus`).
 /// - The daemon rejects the value with
 ///   `org.freedesktop.DBus.Error.InvalidArgs` (for example, a value
 ///   outside the 100..=2000 range).
@@ -726,7 +744,9 @@ pub(crate) fn push_popup_width(value: u32) -> Result<(), glib::Error> {
 ///
 /// Returns the underlying `glib::Error` when:
 /// - The session bus isn't reachable.
-/// - No daemon owns the `org.nwg.Notifications` name.
+/// - The daemon isn't running and D-Bus auto-activation can't recover
+///   (the `org.nwg.Notifications.service` file is missing, or its
+///   `Exec=` path doesn't resolve — see `make install-dbus`).
 /// - The daemon rejects the value with
 ///   `org.freedesktop.DBus.Error.InvalidArgs` (for example, a value
 ///   outside the 200..=2000 range).
@@ -744,7 +764,9 @@ pub(crate) fn push_panel_width(value: u32) -> Result<(), glib::Error> {
 ///
 /// Returns the underlying `glib::Error` when:
 /// - The session bus isn't reachable.
-/// - No daemon owns the `org.nwg.Notifications` name.
+/// - The daemon isn't running and D-Bus auto-activation can't recover
+///   (the `org.nwg.Notifications.service` file is missing, or its
+///   `Exec=` path doesn't resolve — see `make install-dbus`).
 /// - The daemon rejects the payload type with
 ///   `org.freedesktop.DBus.Error.InvalidArgs` (only fires on a
 ///   non-`u32` payload — `handle_set_popup_timeout` does not enforce
@@ -763,7 +785,9 @@ pub(crate) fn push_popup_timeout(value: u32) -> Result<(), glib::Error> {
 ///
 /// Returns the underlying `glib::Error` when:
 /// - The session bus isn't reachable.
-/// - No daemon owns the `org.nwg.Notifications` name.
+/// - The daemon isn't running and D-Bus auto-activation can't recover
+///   (the `org.nwg.Notifications.service` file is missing, or its
+///   `Exec=` path doesn't resolve — see `make install-dbus`).
 /// - The daemon rejects the value with
 ///   `org.freedesktop.DBus.Error.InvalidArgs`. `handle_set_max_popups`
 ///   only rejects two cases: a non-`u32` payload, and the literal
@@ -783,7 +807,9 @@ pub(crate) fn push_max_popups(value: u32) -> Result<(), glib::Error> {
 ///
 /// Returns the underlying `glib::Error` when:
 /// - The session bus isn't reachable.
-/// - No daemon owns the `org.nwg.Notifications` name.
+/// - The daemon isn't running and D-Bus auto-activation can't recover
+///   (the `org.nwg.Notifications.service` file is missing, or its
+///   `Exec=` path doesn't resolve — see `make install-dbus`).
 /// - The daemon rejects the value with
 ///   `org.freedesktop.DBus.Error.InvalidArgs`. `handle_set_max_history`
 ///   only rejects two cases: a non-`u32` payload, and the literal

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -675,9 +675,12 @@ pub(crate) fn query_count_via_dbus() -> Result<u32, glib::Error> {
 /// thing is to spawn one via the `org.nwg.Notifications.service` file,
 /// queue the method call, and let it land on the freshly-spawned daemon.
 /// The fresh daemon loads `config.json`, accepts the `Set*`, and writes
-/// the field back — same end-state as if the daemon had been running
-/// when the push arrived. `SETTER_TIMEOUT_MS` (5s) absorbs the
-/// cold-spawn latency.
+/// the field back — the *persisted-config* outcome matches an update
+/// against an already-running daemon. (Session-only state like active
+/// popup queues or accumulated `dbus_overrides` doesn't carry over from
+/// a non-existent prior daemon — but `--update` only cares about
+/// persistence.) `SETTER_TIMEOUT_MS` (5s) absorbs the cold-spawn
+/// latency.
 fn call_setter_sync(method: &str, payload: glib::Variant) -> Result<(), glib::Error> {
     let connection = gio::bus_get_sync(gio::BusType::Session, gio::Cancellable::NONE)?;
     connection.call_sync(


### PR DESCRIPTION
## Summary

Closes **#67**. Drops `gio::DBusCallFlags::NO_AUTO_START` from `call_setter_sync` so the six `--update` push wrappers auto-spawn the daemon when none is running, instead of failing with `org.freedesktop.DBus.Error.NameHasNoOwner: Destination does not exist`.

The flag had been inherited from `query_count_via_dbus` when `call_setter_sync` was first split out — correct for `--count` (auto-spawning to return zero would be wrong), wrong for `--update` (a write should auto-spawn). Surfaced during smoke-testing of #64.

A new `SETTER_TIMEOUT_MS = 5_000` (vs. `QUERY_COUNT_TIMEOUT_MS = 2_000`) absorbs the cold-spawn latency of GTK4 init + layer-shell + D-Bus name registration. Subsequent calls hit a running daemon and return in milliseconds.

The six push_* wrappers' doc comments updated to reflect the new error envelope: "no daemon" is now reachable only when the `org.nwg.Notifications.service` file is missing or its `Exec=` path is invalid.

`--count` is unchanged — it intentionally keeps `NO_AUTO_START`.

## Test plan

- [x] `make lint` clean (fmt + clippy + test + deny + audit). 107 tests still pass.
- [x] **Manual smoke** (post `make install`):
  - [x] `kill $(pidof nwg-notifications) 2>/dev/null || true; sleep 1; pidof nwg-notifications` → no daemon.
  - [x] `nwg-notifications --update --max-popups 9` → `Updated max_popups`. Fresh daemon PID. `jq .max_popups ~/.config/nwg-notifications/config.json` → `9`.
  - [x] **Regression check on `--count`**: kill daemon, run `nwg-notifications --count` → still errors with `NameHasNoOwner`, still does not auto-spawn. Asymmetry preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update commands no longer fail when the daemon is inactive — the daemon is auto-activated, loads configuration, and the requested updates are applied and persisted.
  * Increased timeout to accommodate cold-start and registration latency during auto-activation.
  * Improved error reporting when the service cannot be resolved or started, so failures are clearer and more actionable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->