### PR TITLE
refactor: centralize config-field-name registry (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `watch_css` for our embedded-default CSS hot-reload, which is
   unchanged. Pulled in to stay current with the nwg-* family.
 
+- Centralized the config-field-name registry into three nested const
+  slices in `config.rs`: `OVERRIDABLE_FIELDS` (10 — boot-time merge
+  inputs), `RELOADABLE_FIELDS` (8 — JSON-visible hot-reload inputs),
+  `LIVE_UPDATABLE_ARGS` (6 — `--update` and D-Bus `Set*` settable).
+  `merge_cli_over_json` and `apply_config_reload` now iterate over
+  the registry and dispatch through a shared `copy_overridable_field`
+  helper instead of hardcoding the same field-name strings in three
+  places. A `field_registry_subsets_are_consistent` test asserts the
+  ⊂ relationships, and `overridable_fields_match_clap_arg_set`
+  catches drift between the registry and `NotificationConfig`'s
+  clap-derived arg set ([#68](https://github.com/jasonherald/nwg-notifications/issues/68)).
+  No behavior change.
+
 ### Fixed
 
 - `nwg-notifications --update --<flag> <value>` now auto-activates the

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,29 @@ const fn default_config_version() -> u32 {
     1
 }
 
+/// Central field-name registry for the JSON config + D-Bus + CLI
+/// merge plumbing. Three nested categories, each a strict superset of
+/// the next (verified by `field_registry_subsets_are_consistent`):
+///
+/// - [`OVERRIDABLE_FIELDS`] (10) — every CLI flag the boot-time
+///   merge tracks via `user_set_args`. Includes `debug` and `wm`,
+///   which are CLI-only and never appear in the JSON.
+/// - [`RELOADABLE_FIELDS`] (8) — `OVERRIDABLE_FIELDS` minus the two
+///   CLI-only flags. The set of fields the inotify hot-reload path
+///   (`apply_config_reload`) reapplies from disk.
+/// - [`LIVE_UPDATABLE_ARGS`] (6) — `RELOADABLE_FIELDS` minus the two
+///   startup-only flags (`persist`, `dnd`). The set of fields the
+///   D-Bus `Set*` handlers can mutate at runtime, and the only fields
+///   `--update` is allowed to push.
+///
+/// Adding a field to `NotificationConfig`: append the snake-cased
+/// arg name to whichever lists apply, then update the per-field
+/// ladders in `merge_cli_over_json` (uses `OVERRIDABLE_FIELDS`),
+/// `apply_config_reload` (uses `RELOADABLE_FIELDS`), and the D-Bus
+/// dispatcher (uses `LIVE_UPDATABLE_ARGS`). The
+/// `overridable_fields_match_clap_arg_set` test catches a missing
+/// `OVERRIDABLE_FIELDS` entry at CI time.
+///
 /// The set of clap arg IDs that are inherently live-updatable. Flags
 /// outside this set (e.g. `--persist`, `--wm`) are skipped in `--update`
 /// mode regardless of whether the user passed them, because pushing them
@@ -148,6 +171,38 @@ pub(crate) const LIVE_UPDATABLE_ARGS: &[&str] = &[
     "popup_timeout",
     "max_popups",
     "max_history",
+];
+
+/// JSON-visible config fields the inotify hot-reload path
+/// (`apply_config_reload`) can re-apply from disk. Strict superset
+/// of [`LIVE_UPDATABLE_ARGS`]: adds `persist` and `dnd`, which are
+/// startup-only flags but legitimate JSON keys.
+pub(crate) const RELOADABLE_FIELDS: &[&str] = &[
+    "popup_position",
+    "popup_width",
+    "panel_width",
+    "popup_timeout",
+    "max_popups",
+    "max_history",
+    "persist",
+    "dnd",
+];
+
+/// Every CLI flag the boot-time merge (`merge_cli_over_json`) and
+/// `user_set_args` track. Strict superset of [`RELOADABLE_FIELDS`]:
+/// adds `debug` and `wm`, which are CLI-only knobs and never appear
+/// in the JSON.
+pub(crate) const OVERRIDABLE_FIELDS: &[&str] = &[
+    "popup_position",
+    "popup_width",
+    "panel_width",
+    "popup_timeout",
+    "max_popups",
+    "max_history",
+    "persist",
+    "dnd",
+    "debug",
+    "wm",
 ];
 
 /// Returns the subset of `LIVE_UPDATABLE_ARGS` whose value source on the
@@ -180,25 +235,11 @@ pub(crate) fn user_set_live_args(matches: &clap::ArgMatches) -> Vec<&'static str
 /// (e.g. `--debug`, `--wm`).
 pub(crate) fn user_set_args(matches: &clap::ArgMatches) -> std::collections::HashSet<&'static str> {
     use clap::parser::ValueSource;
-    let mut out = std::collections::HashSet::new();
-    let candidates = [
-        "popup_position",
-        "popup_timeout",
-        "popup_width",
-        "panel_width",
-        "max_popups",
-        "max_history",
-        "persist",
-        "dnd",
-        "debug",
-        "wm",
-    ];
-    for name in candidates {
-        if matches.value_source(name) == Some(ValueSource::CommandLine) {
-            out.insert(name);
-        }
-    }
-    out
+    OVERRIDABLE_FIELDS
+        .iter()
+        .filter(|name| matches.value_source(name) == Some(ValueSource::CommandLine))
+        .copied()
+        .collect()
 }
 
 #[cfg(test)]
@@ -499,6 +540,92 @@ mod tests {
         assert!(
             !json.contains("update"),
             "update must not appear in JSON; got: {json}"
+        );
+    }
+
+    #[test]
+    fn field_registry_subsets_are_consistent() {
+        // The three lists are nested supersets:
+        //   LIVE_UPDATABLE_ARGS ⊂ RELOADABLE_FIELDS ⊂ OVERRIDABLE_FIELDS
+        // Each ⊂ relationship is a real semantic claim — the boot-time
+        // merge's set of tracked fields is a superset of the
+        // hot-reload path's set, which is a superset of the D-Bus
+        // Set*-able set. Drift breaks the JSON-config contract.
+        let live: std::collections::HashSet<&str> = LIVE_UPDATABLE_ARGS.iter().copied().collect();
+        let reloadable: std::collections::HashSet<&str> =
+            RELOADABLE_FIELDS.iter().copied().collect();
+        let overridable: std::collections::HashSet<&str> =
+            OVERRIDABLE_FIELDS.iter().copied().collect();
+
+        for field in &live {
+            assert!(
+                reloadable.contains(field),
+                "{field} is in LIVE_UPDATABLE_ARGS but missing from RELOADABLE_FIELDS"
+            );
+        }
+        for field in &reloadable {
+            assert!(
+                overridable.contains(field),
+                "{field} is in RELOADABLE_FIELDS but missing from OVERRIDABLE_FIELDS"
+            );
+        }
+
+        // The CLI-only fields are exactly the difference between
+        // OVERRIDABLE and RELOADABLE (debug, wm). If a future spec
+        // change moves one of these into the JSON, both lists need
+        // to grow in sync.
+        let cli_only: std::collections::HashSet<&str> =
+            overridable.difference(&reloadable).copied().collect();
+        let expected_cli_only: std::collections::HashSet<&str> =
+            ["debug", "wm"].iter().copied().collect();
+        assert_eq!(
+            cli_only, expected_cli_only,
+            "OVERRIDABLE - RELOADABLE should be exactly {{debug, wm}}"
+        );
+
+        // Same shape: the difference between RELOADABLE and LIVE is
+        // the startup-only flags (persist, dnd). Adding a `SetPersist`
+        // or `SetDnd` D-Bus method later would shift these.
+        let startup_only: std::collections::HashSet<&str> =
+            reloadable.difference(&live).copied().collect();
+        let expected_startup_only: std::collections::HashSet<&str> =
+            ["persist", "dnd"].iter().copied().collect();
+        assert_eq!(
+            startup_only, expected_startup_only,
+            "RELOADABLE - LIVE should be exactly {{persist, dnd}}"
+        );
+    }
+
+    #[test]
+    fn overridable_fields_match_clap_arg_set() {
+        // Drift detector for the most common case: someone adds a
+        // new field to NotificationConfig + a `#[arg(...)]` line,
+        // but forgets to register the snake-case name in
+        // OVERRIDABLE_FIELDS. clap exposes the registered arg IDs
+        // (which match clap's auto-derived snake_case form for our
+        // struct), so we compare the registry directly.
+        let cmd = NotificationConfig::command();
+        let clap_args: std::collections::HashSet<&str> = cmd
+            .get_arguments()
+            .map(|arg| arg.get_id().as_str())
+            .filter(|id| {
+                // Exclude transient mode flags (count, update) that
+                // are intentionally outside the merge plumbing, and
+                // clap's auto-added help/version.
+                !matches!(*id, "count" | "update" | "help" | "version")
+            })
+            .collect();
+
+        let registry: std::collections::HashSet<&str> =
+            OVERRIDABLE_FIELDS.iter().copied().collect();
+
+        assert_eq!(
+            clap_args,
+            registry,
+            "OVERRIDABLE_FIELDS drifted from clap's arg set. \
+             Missing from registry: {:?}; extra in registry: {:?}.",
+            clap_args.difference(&registry).collect::<Vec<_>>(),
+            registry.difference(&clap_args).collect::<Vec<_>>(),
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,51 +411,65 @@ fn build_on_notify_callback(
 /// explicitly passed it (`user_set` membership), else take the
 /// JSON value. The `count` and `update` fields are always taken
 /// from CLI — they're transient mode flags, not config knobs.
+///
+/// **Coupling:** the per-field ladder below must enumerate every
+/// name in [`config::OVERRIDABLE_FIELDS`]. Drift is detected by
+/// the `overridable_fields_match_clap_arg_set` test in `config.rs`:
+/// adding a new field to `NotificationConfig` without registering
+/// it there will fail CI; the registry is then your prompt to add
+/// a matching `if user_set.contains(...)` arm here.
 fn merge_cli_over_json(
     mut json: NotificationConfig,
     cli: NotificationConfig,
     user_set: &std::collections::HashSet<&'static str>,
 ) -> NotificationConfig {
-    if user_set.contains("popup_position") {
-        json.popup_position = cli.popup_position;
-    }
-    if user_set.contains("popup_timeout") {
-        json.popup_timeout = cli.popup_timeout;
-    }
-    if user_set.contains("popup_width") {
-        json.popup_width = cli.popup_width;
-    }
-    if user_set.contains("panel_width") {
-        json.panel_width = cli.panel_width;
-    }
-    if user_set.contains("max_popups") {
-        json.max_popups = cli.max_popups;
-    }
-    if user_set.contains("max_history") {
-        json.max_history = cli.max_history;
-    }
-    if user_set.contains("persist") {
-        json.persist = cli.persist;
-    }
-    if user_set.contains("dnd") {
-        json.dnd = cli.dnd;
-    }
-    if user_set.contains("debug") {
-        json.debug = cli.debug;
-    }
-    if user_set.contains("wm") {
-        json.wm = cli.wm;
+    for field in config::OVERRIDABLE_FIELDS {
+        if !user_set.contains(field) {
+            continue;
+        }
+        copy_overridable_field(field, &cli, &mut json);
     }
     // count and update are always CLI-driven — they're transient
-    // mode flags, not config knobs.
+    // mode flags, not config knobs, and aren't tracked in
+    // OVERRIDABLE_FIELDS.
     json.count = cli.count;
     json.update = cli.update;
     json
 }
 
+/// Copies the named field from `src` to `dst`. Backing dispatch for
+/// the merge ladders that drive off [`config::OVERRIDABLE_FIELDS`].
+/// Panics if asked for a name not in `OVERRIDABLE_FIELDS` — the
+/// drift-detection tests in `config.rs` ensure that condition is
+/// unreachable in practice.
+fn copy_overridable_field(field: &str, src: &NotificationConfig, dst: &mut NotificationConfig) {
+    match field {
+        "popup_position" => dst.popup_position = src.popup_position,
+        "popup_timeout" => dst.popup_timeout = src.popup_timeout,
+        "popup_width" => dst.popup_width = src.popup_width,
+        "panel_width" => dst.panel_width = src.panel_width,
+        "max_popups" => dst.max_popups = src.max_popups,
+        "max_history" => dst.max_history = src.max_history,
+        "persist" => dst.persist = src.persist,
+        "dnd" => dst.dnd = src.dnd,
+        "debug" => dst.debug = src.debug,
+        "wm" => dst.wm = src.wm,
+        other => unreachable!(
+            "copy_overridable_field called with unregistered field: {other}. \
+             Drift between config::OVERRIDABLE_FIELDS and this match — \
+             register the new field name in config.rs."
+        ),
+    }
+}
+
 /// Applies a hot-reloaded config into the live in-memory config,
 /// per-field. Skips any field whose name is in
 /// `state.dbus_overrides` (Set* sticky for the session).
+///
+/// **Coupling:** the per-field ladder below must enumerate every
+/// name in [`config::RELOADABLE_FIELDS`]. The CLI-only fields
+/// (`debug`, `wm`) are deliberately absent — they don't appear in
+/// the JSON, so there's nothing to reload.
 fn apply_config_reload(
     state: &Rc<RefCell<NotificationState>>,
     config: &Rc<RefCell<NotificationConfig>>,
@@ -463,29 +477,11 @@ fn apply_config_reload(
 ) {
     let overrides = state.borrow().dbus_overrides.clone();
     let mut cfg = config.borrow_mut();
-    if !overrides.contains("popup_position") {
-        cfg.popup_position = new.popup_position;
-    }
-    if !overrides.contains("popup_timeout") {
-        cfg.popup_timeout = new.popup_timeout;
-    }
-    if !overrides.contains("popup_width") {
-        cfg.popup_width = new.popup_width;
-    }
-    if !overrides.contains("panel_width") {
-        cfg.panel_width = new.panel_width;
-    }
-    if !overrides.contains("max_popups") {
-        cfg.max_popups = new.max_popups;
-    }
-    if !overrides.contains("max_history") {
-        cfg.max_history = new.max_history;
-    }
-    if !overrides.contains("persist") {
-        cfg.persist = new.persist;
-    }
-    if !overrides.contains("dnd") {
-        cfg.dnd = new.dnd;
+    for field in config::RELOADABLE_FIELDS {
+        if overrides.contains(field) {
+            continue;
+        }
+        copy_overridable_field(field, new, &mut cfg);
     }
 }
 


### PR DESCRIPTION
## Summary

Closes **#68**. Centralizes the `NotificationConfig` field-name registry that was previously duplicated across `user_set_args`'s inline candidate list, `merge_cli_over_json`'s 10-field ladder, and `apply_config_reload`'s 8-field ladder.

Three nested `const` slices in `config.rs`, each a strict superset of the next:

| Const | Count | Purpose |
|---|---|---|
| `OVERRIDABLE_FIELDS` | 10 | Boot-time merge inputs (`user_set_args`, `merge_cli_over_json`) |
| `RELOADABLE_FIELDS` | 8 | JSON-visible hot-reload inputs (`apply_config_reload`) — excludes `debug`, `wm` |
| `LIVE_UPDATABLE_ARGS` | 6 | `--update` + D-Bus `Set*`-settable — excludes `persist`, `dnd` |

`merge_cli_over_json` and `apply_config_reload` now iterate over the registry and dispatch through a single `copy_overridable_field` helper. The helper has the per-field `match` (necessary because field types differ); iteration order + inclusion comes from the registry. An `unreachable!()` arm catches dispatch-side drift at runtime.

## Drift detection

Two new tests in `config.rs`:

- **`field_registry_subsets_are_consistent`** — asserts `LIVE ⊂ RELOADABLE ⊂ OVERRIDABLE` and that the differences between adjacent pairs are exactly the expected sets.
- **`overridable_fields_match_clap_arg_set`** — walks `NotificationConfig::command().get_arguments()` and asserts the registry matches clap's arg set (modulo `count`/`update`/`help`/`version`). Catches the most common drift: a struct field added without being registered.

## Test plan

- [x] `make lint` clean (fmt + clippy + test + deny + audit). Test count: 107 → 109 (+2 new registry tests).
- [x] **Smoke** (post `make install`):
  - [x] Daemon respawns, loads `config.json` cleanly.
  - [x] `notify-send` works (touches the freedesktop dispatch path).
  - [x] `nwg-notifications --update --max-popups 5` returns `Updated max_popups`, JSON updated → `5` (touches the centralized `copy_overridable_field` dispatch).

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration field handling has been centralized and reorganized to improve code maintainability and consistency. Previously hardcoded field assignments have been replaced with a structured registry-based approach.
  * Enhanced test coverage to detect potential inconsistencies in configuration handling.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->