### PR TITLE
release: stamp 0.4.1 CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
-## [0.4.1] — Unreleased
+## [0.4.1] — 2026-05-05
 
 ### Added
 


### PR DESCRIPTION
## Summary

Stamps the `[0.4.1] — Unreleased` heading with `2026-05-05`, ahead of tagging `v0.4.1`. No code changes; `Cargo.toml` is already at `0.4.1` (set during the JSON-config branch).

## What's in 0.4.1

### Added
- D-Bus auto-activation for the `org.nwg.Notifications` name via a second `.service` file ([#65](https://github.com/jasonherald/nwg-notifications/issues/65) / [#63](https://github.com/jasonherald/nwg-notifications/issues/63), PR [#66](https://github.com/jasonherald/nwg-notifications/pull/66)).
- JSON config file at `~/.config/nwg-notifications/config.json` with layered merge precedence (`defaults < json < CLI < D-Bus Set*`), first-run write-default, atomic `Set*` write-back with full power-loss durability (`tempfile + fsync + parent-dir fsync + rename`), and inotify hot-reload ([#64](https://github.com/jasonherald/nwg-notifications/issues/64), PR [#69](https://github.com/jasonherald/nwg-notifications/pull/69)).

### Changed
- Bumped `nwg-common` `0.4` → `0.5.1`.
- Centralized config-field-name registry across `merge_cli_over_json` / `apply_config_reload` / `user_set_args` ([#68](https://github.com/jasonherald/nwg-notifications/issues/68), PR [#71](https://github.com/jasonherald/nwg-notifications/pull/71)).

### Fixed
- `nwg-notifications --update` now auto-activates the daemon instead of failing with `NameHasNoOwner` when no daemon is running ([#67](https://github.com/jasonherald/nwg-notifications/issues/67), PR [#70](https://github.com/jasonherald/nwg-notifications/pull/70)).

## Post-merge

After merge: tag `v0.4.1` on the merge commit, push tag, then `cargo publish` and `gh release create v0.4.1`.

## Test plan

- [x] `make lint` clean.
- Smoke history: each constituent PR was smoke-tested at merge time (#66, #69, #70, #71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.4.1 release date finalized and documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->