### PR TITLE
release: 0.4.2 — drop uwsm-app default from README autostart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > The full pre-split history is preserved in the monorepo's git log; this
 > file only documents changes from v0.3.0 onward.
 
+## [0.4.2] — 2026-05-05
+
+### Fixed
+
+- README's Hyprland autostart snippet no longer prefixes with
+  `uwsm-app --` by default. The bare
+  `exec-once = nwg-notifications --persist` form works on every
+  Wayland compositor; `uwsm-app --` is now mentioned as optional
+  for users on systemd + uwsm setups (typical Arch). Spotted by
+  [@nwg-piotr](https://github.com/nwg-piotr) in the [#63](https://github.com/jasonherald/nwg-notifications/issues/63)
+  thread — Slackware and other non-systemd distros don't ship
+  `uwsm-app`, so the previous default would silently break for
+  those users.
+
 ## [0.4.1] — 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-notifications"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-notifications"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -146,8 +146,16 @@ Once registered, the daemon auto-starts the first time any app calls **either** 
 
 ```ini
 # ~/.config/hypr/autostart.conf
+exec-once = nwg-notifications --persist
+```
+
+On systems with [`uwsm`](https://github.com/Vladimir-csp/uwsm) (Universal Wayland Session Manager) — common on Arch + systemd setups — you may prefer to prefix with `uwsm-app --` to inherit the systemd user session environment:
+
+```ini
 exec-once = uwsm-app -- nwg-notifications --persist
 ```
+
+The bare form works everywhere; `uwsm-app --` is optional (Slackware and other non-systemd setups don't ship it).
 
 Autostart isn't strictly required thanks to D-Bus auto-activation on either name, but it makes the daemon ready before the first call — avoids a few-hundred-millisecond startup delay on your first toast (or your first nwg-panel count query on cold boot).
 


### PR DESCRIPTION
## Summary

Patch release 0.4.2. Docs-only fix: the README's Hyprland autostart snippet no longer defaults to `uwsm-app -- nwg-notifications --persist`. The bare `exec-once = nwg-notifications --persist` works on every Wayland compositor; `uwsm-app --` is mentioned as optional for users on systemd + uwsm setups.

Refs [#63](https://github.com/jasonherald/nwg-notifications/issues/63) — call-out from @nwg-piotr in that thread that Slackware users don't have `uwsm-app`. (Not closing #63; that thread is broader than this one fix.)

## Changes

- `README.md` — autostart section reworked: bare form first, `uwsm-app --` callout below as optional.
- `Cargo.toml` / `Cargo.lock` — `0.4.1` → `0.4.2`.
- `CHANGELOG.md` — `[0.4.2] — 2026-05-05` entry under `### Fixed`.

No code changes.

## Test plan

- [x] `make lint` clean.
- Visual diff on README — confirmed bare form is the lead snippet, uwsm callout is below as optional.

## Post-merge

Tag `v0.4.2` on the merge commit, push, `cargo publish`, `gh release create v0.4.2`. Same flow as 0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hyprland autostart example; exec-once command now runs directly without the uwsm-app wrapper prefix
  * Expanded compatibility notes clarifying that the uwsm-app wrapper is optional for certain setups and not required across Wayland compositors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->